### PR TITLE
NSBundle.AppStoreReceiptDirectory works now.

### DIFF
--- a/Application/App.rbbas
+++ b/Application/App.rbbas
@@ -5,6 +5,7 @@ Inherits Application
 		Sub NewDocument()
 		  Carbon._TestSelf
 		  CoreFoundation._TestSelf
+		  Cocoa._TestSelf
 		  ATSForFonts.ATSFont.SelfTest
 		  CertTools.SelfTest
 		  TestFileManager

--- a/macoslib/CertTools.rbbas
+++ b/macoslib/CertTools.rbbas
@@ -243,7 +243,7 @@ Protected Module CertTools
 		  https://github.com/macoslib/macoslib
 		
 		Written by Thomas Tempelmann, 31 Oct 2010
-		Last update: 12 Jan 2011
+		Last update: 25 Nov 2012 (Usage note updated to use AppStoreReceiptDirectory function on 10.7 and later)
 	#tag EndNote
 
 	#tag Note, Name = Usage
@@ -271,8 +271,12 @@ Protected Module CertTools
 		Example:
 		
 		  dim f as FolderItem
-		  f = app.ExecutableFile.Parent.Parent // "Contents" folder
-		  f = f.Child("_MASReceipt").Child("receipt") // this is where the App Store puts the receipt when "buying" an app
+		  if IsLion then
+		    f = NSBundle.MainBundle.AppStoreReceiptDirectory()
+		  else
+		    f = App.ExecutableFile.Parent.Parent // "Contents" folder
+		    f = f.Child("_MASReceipt").Child("receipt") // this is where the App Store puts the receipt when "buying" an app
+		  end
 		  if not CertTools.IsValid (CertTools.DeviceGUID, CertTools.ReadReceipt(f), "put the App's Application Identifier here") then
 		    declare sub exit_ lib "System" alias "exit" (code as Integer)
 		    exit_ (173)

--- a/macoslib/Cocoa/Cocoa.rbbas
+++ b/macoslib/Cocoa/Cocoa.rbbas
@@ -626,6 +626,42 @@ Protected Module Cocoa
 		End Function
 	#tag EndMethod
 
+	#tag Method, Flags = &h21
+		Private Sub _testAssert(b as Boolean, msg as String = "")
+		  #if DebugBuild
+		    if not b then
+		      break
+		      #if TargetHasGUI
+		        MsgBox "Test in Cocoa module failed: "+EndOfLine+EndOfLine+msg
+		      #else
+		        Print "Test in Cocoa module failed: "+msg
+		      #endif
+		    end
+		  #endif
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Sub _TestSelf()
+		  // This is an incomplete set of tests to make sure nothing got screwed up too much
+		  
+		  #if DebugBuild
+		    dim f, dir as FolderItem
+		    dim mainBundle as NSBundle = NSBundle.MainBundle
+		    
+		    // Test NSBundle.AppStoreReceiptDirectory
+		    //   For this to work, the path to the receipt file
+		    //   must exist, or we'll get nil from the function.
+		    //   Therefore, we'll add that folder here first.
+		    dir = mainBundle.BundleDirectory.Child("Contents").Child("_MASReceipt")
+		    dir.CreateAsFolder()
+		    f = mainBundle.AppStoreReceiptDirectory()
+		    _testAssert (f <> nil and f.Name = "receipt") ' In case this fails: Did the receipt URL move somewhere else? At least until OSX 10.8 it shouldn't have
+		    
+		  #endif
+		End Sub
+	#tag EndMethod
+
 
 	#tag Note, Name = About
 		From: http://www.declaresub.com/ideclare/Cocoa/index.html

--- a/macoslib/Cocoa/NSBundle.rbbas
+++ b/macoslib/Cocoa/NSBundle.rbbas
@@ -4,12 +4,12 @@ Inherits NSObject
 	#tag Method, Flags = &h0
 		Function AppStoreReceiptDirectory() As FolderItem
 		  #if targetMacOS
-		    //this method should be invoked on the application bundle; that is, the object returned by NSBundle.MainBundle.
+		    // This method is to be invoked on the application bundle; that is, the object returned by NSBundle.MainBundle.
 		    
 		    if IsLion then
 		      declare function appStoreReceiptURL lib CocoaLib selector "appStoreReceiptURL" (obj_id as Ptr) as Ptr
 		      
-		      return bundleDirectory(self)
+		      return bundleDirectory(appStoreReceiptURL(self))
 		    else
 		      return nil
 		    end if
@@ -19,13 +19,34 @@ Inherits NSObject
 		End Function
 	#tag EndMethod
 
+	#tag Method, Flags = &h0
+		Function BundleDirectory() As FolderItem
+		  #if targetMacOS
+		    declare function bundleURL lib CocoaLib selector "bundleURL" (obj_id as Ptr) as Ptr
+		    
+		    return bundleDirectory(bundleURL(self))
+		  #endif
+		  
+		  
+		End Function
+	#tag EndMethod
+
 	#tag Method, Flags = &h21
 		Private Shared Function bundleDirectory(urlRef as Ptr) As FolderItem
+		  // May return nil if the url points to a nonexisting path.
+		  // But even if it's not nil, the item at the URL may still not exist!
+		  
 		  #if targetMacOS
 		    if urlRef <> nil then
 		      dim url as new CFURL(urlRef, not CFType.hasOwnership)
-		      return new FolderItem(url.StringValue, FolderItem.PathTypeURL)
-		      
+		      #pragma BreakOnExceptions off
+		      try
+		        return new FolderItem(url.StringValue, FolderItem.PathTypeURL)
+		      catch UnsupportedFormatException
+		        // path invalid - probably not existing
+		        return nil
+		      end try
+		      #pragma BreakOnExceptions reset
 		    else
 		      return nil
 		    end if


### PR DESCRIPTION
• NSBundle.AppStoreReceiptDirectory works now.
• Adds Test-Method to Cocoa module
• Updates the note on using CertTools
• NSBundle.bundleDirectory(urlRef as Ptr) now returns nil if url doesn't exist instead of raising an exception.
• Add NSBundle.BundleDirectory() to return the FolderItem of the bundle's directory.
