### PR TITLE
Mostly minor changes/additions

### DIFF
--- a/About.rbbas
+++ b/About.rbbas
@@ -19,6 +19,17 @@ Protected Module About
 		These release notes were added as of version 100. Check the git history for previous release notes.
 		Add new notes above existing ones, and remember to increment the Version constant.
 		
+		114: 2012-11-30 by KT
+		- CoreFoundation.Write: Added CFPropertyListWrite to replace the deprecated CFPropertyListWriteToStream.
+		- CoreFoundation.XMLValue: Added code for CFPropertyListCreateData to replace deprecated CFPropertyListCreateXMLData.
+		- Added some comments.
+		- Added option to MacPListBrowser.SaveToFile to allow saving as binary.
+		- Added more unused method parameter pragmas.
+		- Added XMLValue as alias for PListStringValue in MacPListBrowser.
+		
+		113: 2012-11-29 by CY
+		- Attempt to get NSSearchField to participate in key-view loop.
+		
 		112: 2012-11-28 by KT
 		- Updated DICT_CaseSensitiveDictionary in Additional Modules.
 		- Minor spelling fixes in comments.
@@ -103,7 +114,7 @@ Protected Module About
 	#tag EndNote
 
 
-	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"111", Scope = Protected
+	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"114", Scope = Protected
 	#tag EndConstant
 
 

--- a/Additional Modules/KT's PList Stuff/MacPListBrowser.rbbas
+++ b/Additional Modules/KT's PList Stuff/MacPListBrowser.rbbas
@@ -1057,20 +1057,20 @@ Protected Class MacPListBrowser
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Function SaveToFile(f As FolderItem) As Boolean
+		Function SaveToFile(f As FolderItem, asBinary As Boolean = False) As Boolean
 		  dim r as boolean
 		  
 		  #if TargetMacOS
 		    
 		    if f <> nil then
-		      dim cf as CoreFoundation.CFType = CoreFoundation.CFTypeFromVariant( VariantValue )
-		      dim plist as CoreFoundation.CFPropertyList = CoreFoundation.CFPropertyList( cf )
-		      r = plist.WriteToFile( f, true )
+		      dim plist as CoreFoundation.CFPropertyList = me.CFPropertyListValue()
+		      r = plist.WriteToFile( f, not asBinary )
 		    end if
 		    
 		  #else
 		    
 		    #pragma unused f
+		    #pragma unused asBinary
 		    
 		  #endif
 		  
@@ -1112,6 +1112,13 @@ Protected Class MacPListBrowser
 		End Function
 	#tag EndMethod
 
+	#tag Method, Flags = &h0
+		Function XMLValue() As String
+		  // Alias for...
+		  return me.PListStringValue
+		End Function
+	#tag EndMethod
+
 
 	#tag Note, Name = Legal
 		This class was created by Kem Tekinay, MacTechnologies Consulting (ktekinay@mactechnologies.com).
@@ -1134,6 +1141,10 @@ Protected Class MacPListBrowser
 	#tag EndNote
 
 	#tag Note, Name = Release Notes
+		1.3
+		- Added XMLValue as alias for PListStringValue.
+		- Added optional parameter asBinary to SaveToFile.
+		
 		1.2 (started numbering releases):
 		- Added features for case-sensitivity.
 		- The DICT_CaseSensitiveDictionary class is now required.
@@ -1483,7 +1494,7 @@ Protected Class MacPListBrowser
 	#tag EndProperty
 
 
-	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"1.2", Scope = Public
+	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"1.3", Scope = Public
 	#tag EndConstant
 
 

--- a/macoslib/Cocoa/NSArray.rbbas
+++ b/macoslib/Cocoa/NSArray.rbbas
@@ -100,6 +100,8 @@ Inherits NSObject
 		  
 		  #if TargetMacOS
 		    'declare function CFArrayGetCount lib CarbonLib (theArray as Ptr) as Integer
+		    
+		    // Introduced in MacOS X 10.0.
 		    declare function objectAtIndex lib CocoaLib selector "objectAtIndex:" (theArray as Ptr, idx as Integer) as Ptr
 		    
 		    if self <> nil then
@@ -128,6 +130,8 @@ Inherits NSObject
 		Function Value(index as Integer) As Ptr
 		  #if TargetMacOS
 		    'declare function CFArrayGetCount lib CarbonLib (theArray as Ptr) as Integer
+		    
+		    // Introduced in MacOS X 10.0.
 		    declare function objectAtIndex lib CocoaLib selector "objectAtIndex:" (theArray as Ptr, idx as Integer) as Ptr
 		    
 		    if self <> nil then

--- a/macoslib/CoreFoundation/CFBoolean.rbbas
+++ b/macoslib/CoreFoundation/CFBoolean.rbbas
@@ -168,6 +168,11 @@ Implements CFPropertyList
 
 	#tag ViewBehavior
 		#tag ViewProperty
+			Name="BooleanValue"
+			Group="Behavior"
+			Type="Boolean"
+		#tag EndViewProperty
+		#tag ViewProperty
 			Name="Description"
 			Group="Behavior"
 			Type="String"


### PR DESCRIPTION
- CoreFoundation.Write: Added CFPropertyListWrite to replace the deprecated CFPropertyListWriteToStream.
- CoreFoundation.XMLValue: Added code for CFPropertyListCreateData to replace deprecated CFPropertyListCreateXMLData.
- Added some comments.
- Added option to MacPListBrowser.SaveToFile to allow saving as binary.
- Added more unused method parameter pragmas.
- Added XMLValue as alias for PListStringValue in MacPListBrowser.
