### PR TITLE
Caching for IsFunctionAvailable, minor changes

### DIFF
--- a/About.rbbas
+++ b/About.rbbas
@@ -19,6 +19,19 @@ Protected Module About
 		These release notes were added as of version 100. Check the git history for previous release notes.
 		Add new notes above existing ones, and remember to increment the Version constant.
 		
+		116: 2012-12-01 by KT
+		- Added caching for System.IsFunctionAvailable calls.
+		- CoreFoundation._TestSelf: Created switches as constants for each test category.
+		- CFBundle.Load: Removed older system function check and call, raise any returned CFError as an exception.
+		- ATSFont.File: Added check for older function because the documentation for both functions seems to have 
+		  dropped off of Apple's site except for a PDF that says it's all deprecated as of OS X 10.6 in favor of 
+		  Core Text.
+		- Win32Error.FormatErrorMessage: Added caching and checks for both system functions, just to be safe.
+		
+		115: 2012-12-01 by CY
+		- Remove assignment to NSControl.AcceptFocus; update NSSearchField1 pro…
+		- Fix a bug in NSSearchField.MaxRecentSearches.
+		
 		114: 2012-11-30 by KT
 		- CoreFoundation.Write: Added CFPropertyListWrite to replace the deprecated CFPropertyListWriteToStream.
 		- CoreFoundation.XMLValue: Added code for CFPropertyListCreateData to replace deprecated CFPropertyListCreateXMLData.
@@ -114,7 +127,7 @@ Protected Module About
 	#tag EndNote
 
 
-	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"114", Scope = Protected
+	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"115", Scope = Protected
 	#tag EndConstant
 
 

--- a/macoslib.rbvcp
+++ b/macoslib.rbvcp
@@ -525,5 +525,5 @@ AppIcon=macoslib.rbres;&h0
 OSXBundleID=com.declaresub.macoslib
 DebuggerCommandLine=
 UseGDIPlus=False
-UseBuildsFolder=False
+UseBuildsFolder=True
 IsWebProject=False

--- a/macoslib/CoreFoundation/CFURL.rbbas
+++ b/macoslib/CoreFoundation/CFURL.rbbas
@@ -103,7 +103,14 @@ Inherits CFType
 		    if resolveIfAlias then
 		      
 		      #if TargetMacOS
-		        if System.IsFunctionAvailable( "CFURLCreateBookmarkDataFromFile", CarbonLib ) then // This function was introduced in OS X 10.6.
+		        static functionNeedsCheck as boolean = true
+		        static functionIsAvailable as boolean
+		        if functionNeedsCheck then
+		          functionIsAvailable = System.IsFunctionAvailable( "CFURLCreateBookmarkDataFromFile", CarbonLib ) // This function was introduced in OS X 10.6.
+		          functionNeedsCheck = false
+		        end if
+		        
+		        if functionIsAvailable then 
 		          try
 		            dim data as CFData = CFURL.CreateBookmarkDataFromFile( f )
 		            dim url as CFURL = CFURL.CreateByResolvingBookmarkData( data )
@@ -113,7 +120,7 @@ Inherits CFType
 		            resolveIfAlias = false // Nothing left to resolve
 		          catch
 		          end try
-		        end if // System.IsFunctionAvailable
+		        end if // functionIsAvailable
 		      #endif
 		      
 		      // See if the alias still needs to be resolved

--- a/macoslib/CoreFoundation/CoreFoundation.rbbas
+++ b/macoslib/CoreFoundation/CoreFoundation.rbbas
@@ -407,18 +407,23 @@ Module CoreFoundation
 		Function Write(extends propertyList as CFPropertyList, openedWriteStream as CFWriteStream, format as Integer, ByRef errorMessageOut as String) As Boolean
 		  #if TargetMacOS
 		    
-		    // Introduced in MacOS X 10.2 (deprecated, use CFPropertyListWrite instead)
-		    declare function CFPropertyListWriteToStream lib CarbonLib (propertyList as Ptr, stream as Ptr, format as Integer, ByRef errMsg as CFStringRef) as Integer
-		    
-		    // Introduced in MacOS X 10.6.
-		    soft declare function CFPropertyListWrite lib CarbonLib (propertyList as Ptr, stream as Ptr, format as Integer, options as UInt32, ByRef errMsg as CFStringRef) as Integer
+		    static newFunctionNeedsCheck as boolean = true
+		    static newFunctionIsAvailable as boolean
+		    if newFunctionNeedsCheck then
+		      newFunctionIsAvailable = System.IsFunctionAvailable( "CFPropertyListWrite", CarbonLib )
+		      newFunctionNeedsCheck = false
+		    end if
 		    
 		    dim strRef as CFStringRef
 		    dim written as Integer
-		    if System.IsFunctionAvailable( "CFPropertyListWrite", CarbonLib ) then
+		    if newFunctionIsAvailable then
+		      // Introduced in MacOS X 10.6.
+		      soft declare function CFPropertyListWrite lib CarbonLib (propertyList as Ptr, stream as Ptr, format as Integer, options as UInt32, ByRef errMsg as CFStringRef) as Integer
 		      written = _
 		      CFPropertyListWrite (propertyList.Reference, openedWriteStream.Reference, format, 0, strRef)
 		    else
+		      // Introduced in MacOS X 10.2 (deprecated, use CFPropertyListWrite instead)
+		      declare function CFPropertyListWriteToStream lib CarbonLib (propertyList as Ptr, stream as Ptr, format as Integer, ByRef errMsg as CFStringRef) as Integer
 		      written = _
 		      CFPropertyListWriteToStream (propertyList.Reference, openedWriteStream.Reference, format, strRef)
 		    end if
@@ -443,15 +448,19 @@ Module CoreFoundation
 		Function XMLValue(extends propertyList as CFPropertyList) As String
 		  #if TargetMacOS
 		    
-		    // Introduced in MacOS X 10.2 (deprecated, use CFPropertyListCreateData instead).
-		    declare function CFPropertyListCreateXMLData lib CarbonLib (allocator as Ptr, propertyList as Ptr) as Ptr
-		    
-		    // Introduced in MacOS X 10.6.
-		    soft declare function CFPropertyListCreateData lib CarbonLib _
-		    ( allocator as Ptr, propertyList as Ptr, format as Integer, options as UInt32, ByRef err as Ptr ) as Ptr
+		    static newFunctionNeedsCheck as boolean = true
+		    static newFunctionIsAvailable as boolean
+		    if newFunctionNeedsCheck then
+		      newFunctionIsAvailable = System.IsFunctionAvailable( "CFPropertyListCreateData", CarbonLib )
+		      newFunctionNeedsCheck = false
+		    end if
 		    
 		    dim xmlDataRef as Ptr
-		    if System.IsFunctionAvailable( "CFPropertyListCreateData", CarbonLib ) then
+		    if newFunctionIsAvailable then
+		      
+		      // Introduced in MacOS X 10.6.
+		      soft declare function CFPropertyListCreateData lib CarbonLib _
+		      ( allocator as Ptr, propertyList as Ptr, format as Integer, options as UInt32, ByRef err as Ptr ) as Ptr
 		      
 		      dim err as Ptr
 		      xmlDataRef = CFPropertyListCreateData( nil, propertyList.Reference, kCFPropertyListXMLFormat_v1_0, 0, err )
@@ -460,6 +469,9 @@ Module CoreFoundation
 		      end if
 		      
 		    else
+		      
+		      // Introduced in MacOS X 10.2 (deprecated, use CFPropertyListCreateData instead).
+		      declare function CFPropertyListCreateXMLData lib CarbonLib (allocator as Ptr, propertyList as Ptr) as Ptr
 		      
 		      xmlDataRef = CFPropertyListCreateXMLData(nil, propertyList.Reference)
 		      
@@ -500,12 +512,26 @@ Module CoreFoundation
 		  
 		  #if DebugBuild
 		    
+		    // Flip the switches for the tests below here.
+		    // Use true and FALSE as values to help distinguish easily.
+		    const kTestCFArray = true
+		    const kTestCFNumber = true
+		    const kTestCFString = true
+		    const kTestCFBoolean = true
+		    const kTestCFPreferences = true
+		    const kTestCFURL = true
+		    const kTestCFDate = true
+		    const kTestCFTimeZone = true
+		    const kTestCFStream = true
+		    const kTestCFBundleAndCFPropertyList = FALSE
+		    'const kTestCFSocket = FALSE
+		    
 		    dim s as String
 		    s = CFBundle.NewCFBundleFromID(BundleID).Identifier
 		    
 		    dim cft as CFType
 		    
-		    if true then
+		    if kTestCFArray then
 		      dim vals() as CFString
 		      vals.Append "a"
 		      vals.Append "b"
@@ -518,7 +544,7 @@ Module CoreFoundation
 		    end // at this point the CFString objects should all get deallocated
 		    
 		    // Test CFNumber operations
-		    if true then
+		    if kTestCFNumber then
 		      dim cf1, cf2 as CFNumber
 		      cf1 = new CFNumber(1)
 		      _testAssert cf2 is nil
@@ -542,7 +568,7 @@ Module CoreFoundation
 		    end
 		    
 		    // Test CFString operations
-		    if true then
+		    if kTestCFString then
 		      dim s1 as CFString = "z"
 		      dim s2 as CFString = "a"
 		      _testAssert s2 < s1
@@ -556,7 +582,7 @@ Module CoreFoundation
 		    end if
 		    
 		    // Test CFBoolean operations
-		    if true then
+		    if kTestCFBoolean then
 		      dim cfbF as new CFBoolean( False )
 		      dim cfbT as CFBoolean = true
 		      _testAssert cfbT = true
@@ -569,7 +595,7 @@ Module CoreFoundation
 		    end if
 		    
 		    // Test the CFPreferences functionality
-		    if true then
+		    if kTestCFPreferences then
 		      dim cf1 as CFNumber
 		      dim prefs as CFPreferences
 		      dim prefKeys() as String = prefs.Keys
@@ -590,7 +616,7 @@ Module CoreFoundation
 		    end
 		    
 		    // Test CFURL
-		    if true then
+		    if kTestCFURL then
 		      dim url as new CFURL(SpecialFolder.System)
 		      _testAssert url.Scheme = "file"
 		      _testAssert url.NetLocation = "localhost"
@@ -603,7 +629,7 @@ Module CoreFoundation
 		    end
 		    
 		    // Test CFDate
-		    if true then
+		    if kTestCFDate then
 		      dim d1 as new Date
 		      dim d2 as new Date
 		      dim d3 as date
@@ -619,14 +645,14 @@ Module CoreFoundation
 		    end if
 		    
 		    // Test CFTimeZone
-		    if true then
+		    if kTestCFTimeZone then
 		      dim zonenames() as String = CFTimeZone.NameList()
 		      dim tzone as new CFTimeZone(zonenames(1))
 		      _testAssert tzone.Name = zonenames(1)
 		    end
 		    
 		    // Test CFStreams
-		    if true then
+		    if kTestCFStream then
 		      dim reader as CFReadStream
 		      'dim writer as CFWriteStream
 		      reader = new CFReadStream("12345")
@@ -658,7 +684,7 @@ Module CoreFoundation
 		    end if
 		    
 		    // Test CFBundle and CFPropertyList
-		    if false then
+		    if kTestCFBundleAndCFPropertyList then
 		      // get this app's Info.plist contents via CFBundle.InfoDictionary
 		      dim bndl as CFBundle = CFBundle.Application
 		      dim infodict as CFDictionary = bndl.InfoDictionary
@@ -701,7 +727,7 @@ Module CoreFoundation
 		    end
 		    
 		    '// Test CFSocket (TCP/IP)
-		    '#if false then
+		    '#if kTestCFSocket then
 		    '// (TT 6 Dec 09) this is not working - at least not when reading and writing within same process
 		    'declare function CFRunLoopGetCurrent lib CarbonLib () as Ptr
 		    'declare sub CFReadStreamScheduleWithRunLoop lib CarbonLib (streamRef as Ptr, runLoopRef as Ptr, mode as CFStringRef)
@@ -755,7 +781,7 @@ Module CoreFoundation
 		    '#endif
 		    '
 		    '// Test CFSockets (Unix Domain Sockets)
-		    '#if false then
+		    '#if kTestCFSocket then
 		    '// (TT 6 Dec 09) this is not working - at least not when reading and writing within same process
 		    'declare function CFRunLoopGetCurrent lib CarbonLib () as Ptr
 		    'declare sub CFReadStreamScheduleWithRunLoop lib CarbonLib (streamRef as Ptr, runLoopRef as Ptr, mode as CFStringRef)

--- a/macoslib/Exception Classes/Win32Error.rbbas
+++ b/macoslib/Exception Classes/Win32Error.rbbas
@@ -11,12 +11,21 @@ Inherits OSError
 	#tag Method, Flags = &h0
 		 Shared Function FormatErrorMessage(errorcode as Integer) As String
 		  #if targetWin32
-		    soft declare function FormatMessageA lib win32.Kernel32 (dwFlags As integer, lpSource As integer, dwMessageId As integer, dwLanguageId As integer, lpBuffer As ptr, nSize As integer, Arguments As integer) As integer
-		    soft declare function FormatMessageW lib win32.Kernel32 (dwFlags As integer, lpSource As integer, dwMessageId As integer, dwLanguageId As integer, lpBuffer As ptr, nSize As integer, Arguments As integer) As integer
 		    
 		    const FORMAT_MESSAGE_FROM_SYSTEM = &h1000
 		    
-		    if System.IsFunctionAvailable("FormatMessageW", Win32.Kernel32) then
+		    static functionsNeedCheck as boolean = true
+		    static newFunctionIsAvailable as boolean
+		    static oldFunctionIsAvailable as boolean
+		    if functionsNeedCheck then
+		      newFunctionIsAvailable = System.IsFunctionAvailable( "FormatMessageW", Win32.Kernel32 )
+		      oldFunctionIsAvailable = System.IsFunctionAvailable( "FormatMessageA", Win32.Kernel32 )
+		      functionsNeedCheck = false
+		    end if
+		    
+		    if newFunctionIsAvailable then
+		      soft declare function FormatMessageW lib win32.Kernel32 (dwFlags As integer, lpSource As integer, dwMessageId As integer, dwLanguageId As integer, lpBuffer As ptr, nSize As integer, Arguments As integer) As integer
+		      
 		      dim buffer as new MemoryBlock(2048)
 		      dim result as Integer = FormatMessageW( FORMAT_MESSAGE_FROM_SYSTEM, 0, errorcode, 0 , buffer, buffer.Size, 0 )
 		      if result <> 0 then
@@ -24,7 +33,9 @@ Inherits OSError
 		      else
 		        return ""
 		      end if
-		    else
+		    elseif oldFunctionIsAvailable then
+		      soft declare function FormatMessageA lib win32.Kernel32 (dwFlags As integer, lpSource As integer, dwMessageId As integer, dwLanguageId As integer, lpBuffer As ptr, nSize As integer, Arguments As integer) As integer
+		      
 		      dim buffer as new MemoryBlock(1024)
 		      dim result as Integer = FormatMessageA( FORMAT_MESSAGE_FROM_SYSTEM, 0, errorcode, 0 , buffer, buffer.Size, 0 )
 		      if result <> 0 then


### PR DESCRIPTION
- Added caching for System.IsFunctionAvailable calls.
- CoreFoundation._TestSelf: Created switches as constants for each test category.
- CFBundle.Load: Removed older system function check and call, raise any returned CFError as an exception.
- ATSFont.File: Added check for older function because the documentation for both functions seems to have 
  dropped off of Apple's site except for a PDF that says it's all deprecated as of OS X 10.6 in favor of 
  Core Text.
- Win32Error.FormatErrorMessage: Added caching and checks for both system functions, just to be safe.
