### PR TITLE
Addressed unused vars, misc. changes

### DIFF
--- a/About.rbbas
+++ b/About.rbbas
@@ -32,6 +32,10 @@ Protected Module About
 		These release notes were added as of version 100. Check the git history for previous release notes.
 		Add new notes above existing ones, and remember to increment the Version constant.
 		
+		119: 2012-12-12 by KT
+		- Removed legal notice from NativeSubclass.DictionaryCaseSensitive.
+		- Added lines to prevent compiler from complaining about unused variables.
+		
 		118: 2012-12-11 by KT
 		- Added NativeSubclass module to house subclasses of native types.
 		- Added NativeSubclass.DictionaryCaseSensitive.
@@ -152,7 +156,7 @@ Protected Module About
 	#tag EndNote
 
 
-	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"118", Scope = Protected
+	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"119", Scope = Protected
 	#tag EndConstant
 
 

--- a/macoslib/Misc./NativeSubclass/DictionaryCaseSensitive.rbbas
+++ b/macoslib/Misc./NativeSubclass/DictionaryCaseSensitive.rbbas
@@ -622,27 +622,6 @@ Inherits Dictionary
 	#tag EndMethod
 
 
-	#tag Note, Name = Legal
-		This class was created by Kem Tekinay, MacTechnologies Consulting (ktekinay@mactechnologies.com).
-		It is copyright ©2012, all rights reserved.
-		
-		You may use this class AS IS at your own risk for any purpose. The author does not warrant its use
-		for any particular purpose and disavows any responsibility for bad design, poor execution,
-		or any other faults.
-		
-		The author does not actively support this class, although comments and recommendations
-		are welcome.
-		
-		You may modify code in this class as long as those modifications are clearly indicated
-		via comments in the source code.
-		
-		You may distribute this class, modified or unmodified, as long as any modifications
-		are clearly indicated, as noted above, and this copyright notice is not disturbed or removed.
-		
-		If you do make useful modifications, please let me know so I can include them in
-		future versions.
-	#tag EndNote
-
 	#tag Note, Name = Usage
 		
 		This is a drop-in replacement for the dictionary with some modifications and additional functions:

--- a/macoslib/ResourceForkReplacement/MacResourceFork.rbbas
+++ b/macoslib/ResourceForkReplacement/MacResourceFork.rbbas
@@ -48,6 +48,9 @@ Class MacResourceFork
 		    mFileHandle = hdl
 		    mResHandle = ResourceChainSaver.CurResFile
 		  end
+		  
+		  saver = nil // Keeps the compiler from complaining
+		  
 		End Sub
 	#tag EndMethod
 
@@ -86,6 +89,9 @@ Class MacResourceFork
 		  declare function GetResAttrs lib CarbonLib (hdl as Ptr) as Integer
 		  dim res as new ResourceAccessor (mResHandle)
 		  return GetResAttrs (ResourceItem.ByID(mResHandle, type, id).Handle)
+		  
+		  res = nil // Keeps the compiler from complaining
+		  
 		End Function
 	#tag EndMethod
 
@@ -96,6 +102,8 @@ Class MacResourceFork
 		  dim res as new ResourceAccessor (mResHandle)
 		  
 		  return Count1Resources (type)
+		  
+		  res = nil // Keeps the compiler from complaining
 		End Function
 	#tag EndMethod
 
@@ -163,6 +171,8 @@ Class MacResourceFork
 		  dim t as OSType
 		  Get1IndType t, index_0+1
 		  return t
+		  
+		  res = nil // Keeps the compiler from complaining
 		End Function
 	#tag EndMethod
 
@@ -171,6 +181,9 @@ Class MacResourceFork
 		  declare function Count1Types lib CarbonLib () as Integer
 		  dim res as new ResourceAccessor (mResHandle)
 		  return Count1Types
+		  
+		  res = nil // Keeps the compiler from complaining
+		  
 		End Function
 	#tag EndMethod
 


### PR DESCRIPTION
- Removed legal notice from NativeSubclass.DictionaryCaseSensitive.
- Added lines to prevent compiler from complaining about unused variables.
