### PR TITLE
Added a link to the Docgen wiki in the About module

### DIFF
--- a/About.rbbas
+++ b/About.rbbas
@@ -19,7 +19,7 @@ Protected Module About
 	#tag EndNote
 
 	#tag Note, Name = Documentation
-		The macoslib documentation is provided inside macoslib itself as described at http://http://ufos-software.com/docgen/
+		The macoslib documentation is provided inside macoslib itself as described at http://ufos-software.com/docgen/
 		
 		Eventually, Docgen (1) will be able to export the full documentation of macoslib
 		


### PR DESCRIPTION
Signed-off-by: Stéphane Mons st.mons.lists@free.fr

I created a Docgen wiki on my website and added the link to the About module.
