### PR TITLE
Various

### DIFF
--- a/About.rbbas
+++ b/About.rbbas
@@ -6,7 +6,6 @@ Protected Module About
 		Original sources are located here:  https://github.com/macoslib/macoslib
 		
 		Requires REALbasic 2007r4 or later and MacOS X 10.5 or later.
-		
 	#tag EndNote
 
 	#tag Note, Name = Contributors
@@ -28,7 +27,6 @@ Protected Module About
 		
 		
 		(1) "Docgen" is a codename. The final software name has not been chosen yet.
-		
 	#tag EndNote
 
 	#tag Note, Name = How To Use
@@ -55,6 +53,16 @@ Protected Module About
 		These release notes were added as of version 100. Check the git history for previous release notes.
 		Add new notes above existing ones, and remember to increment the Version constant.
 		Contributors are identified by initials. See the "Contributors" note for full names.
+		
+		135: 2013-07-06 by KT
+		- Changed constant name in MacSystemProfiler to kSystemProfilerShellPath for clarity.
+		- Copied GetFolderItemFromPOSIXPath from Cocoa to FileManager and made it Global.
+		- Deprecated Cocoa.GetFolderItemFromPOSIXPath.
+		
+		134: 2013-07-05 by SM
+		- Added link to Docgen wiki to About.
+		- Removed ShellPath from FSEvent.
+		- Set computed variables to static in StringExtension.FormatSize.
 		
 		133: 2013-07-03 by KT
 		- Added pragmas for unused method parameters.
@@ -235,7 +243,7 @@ Protected Module About
 	#tag EndNote
 
 
-	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"133", Scope = Protected
+	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"135", Scope = Protected
 	#tag EndConstant
 
 

--- a/Additional Modules/Class Extensions/MacFSEvents/MacFSEvent.rbbas
+++ b/Additional Modules/Class Extensions/MacFSEvents/MacFSEvent.rbbas
@@ -39,7 +39,7 @@ Class MacFSEvent
 		  //@ If you set onlyIfFolderItemExists then this method will return nil if the FolderItem does not exist
 		  
 		  #if TargetMacOS
-		    dim f as FolderItem = Cocoa.GetFolderItemFromPOSIXPath( Path )
+		    dim f as FolderItem = GetFolderItemFromPOSIXPath( Path )
 		    
 		    if f<>nil then
 		      if onlyIfFolderItemExists then

--- a/Additional Modules/KT's PList Stuff/MacSystemProfiler.rbbas
+++ b/Additional Modules/KT's PList Stuff/MacSystemProfiler.rbbas
@@ -382,13 +382,22 @@ Protected Class MacSystemProfiler
 
 	#tag Method, Flags = &h0
 		Function Section(dataType As String) As MacPListBrowser
-		  dataType = pFixDataType( dataType )
-		  if dataType = "" and zDataTypes.Ubound = 0 then
-		    dataType = zDataTypes( 0 )
-		  end if
-		  dim r as MacPListBrowser = zSections.Value( dataType )
-		  return r.Clone
-		  
+		  #if TargetMacOS
+		    
+		    dataType = pFixDataType( dataType )
+		    if dataType = "" and zDataTypes.Ubound = 0 then
+		      dataType = zDataTypes( 0 )
+		    end if
+		    dim r as MacPListBrowser = zSections.Value( dataType )
+		    return r.Clone
+		    
+		  #else
+		    
+		    #pragma unused dataType
+		    
+		    return nil
+		    
+		  #endif
 		End Function
 	#tag EndMethod
 
@@ -735,6 +744,10 @@ Protected Class MacSystemProfiler
 	#tag EndNote
 
 	#tag Note, Name = Release Notes
+		1.01:
+		- Changed constant name to kSystemProfilerShellPath from kSystemProfiler to be more descriptive.
+		- Wrapped the Section code in an #if.
+		
 		1.0:
 		- Initial release.
 	#tag EndNote
@@ -1067,7 +1080,7 @@ Protected Class MacSystemProfiler
 	#tag Constant, Name = kSystemProfilerShellPath, Type = String, Dynamic = False, Default = \"/usr/sbin/system_profiler", Scope = Protected
 	#tag EndConstant
 
-	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"1.0", Scope = Public
+	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"1.01", Scope = Public
 	#tag EndConstant
 
 

--- a/macoslib/Cocoa/Cocoa.rbbas
+++ b/macoslib/Cocoa/Cocoa.rbbas
@@ -113,31 +113,12 @@ Protected Module Cocoa
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function GetFolderItemFromPOSIXPath(absolutePath as String) As FolderItem
-		  // Note: The passed path must be absolute, i.e. start from root with "/"
+		Attributes( deprecated = "FileManager.GetFolderItemFromPOSIXPath" ) Protected Function GetFolderItemFromPOSIXPath(absolutePath as String) As FolderItem
+		  // THIS FUNCTION IS DEPRECATED.
+		  // Use FileManager.GetFolderItemFromPOSIXPath or just GetFolderItemFromPOSIXPath instead.
 		  
-		  #if TargetMacOS
-		    
-		    'declare function CFURLCopyAbsoluteURL lib CarbonLib (relativeURL as Ptr) as Ptr
-		    declare function CFURLCreateWithFileSystemPath lib CarbonLib (allocator as ptr, filePath as CFStringRef, pathStyle as Integer, isDirectory as Boolean) as Ptr
-		    declare function CFURLGetString lib CarbonLib (anURL as Ptr) as Ptr
-		    declare sub CFRelease lib CarbonLib (cf as Ptr)
-		    declare function CFRetain lib CarbonLib (cf as Ptr) as CFStringRef
-		    'declare sub CFShow lib CarbonLib (obj as Ptr)
-		    
-		    const kCFURLPOSIXPathStyle = 0
-		    
-		    dim url as Ptr = CFURLCreateWithFileSystemPath(nil, absolutePath, kCFURLPOSIXPathStyle, true)
-		    dim str as CFStringRef = CFRetain (CFURLGetString (url))
-		    CFRelease (url)
-		    dim f as FolderItem = GetFolderItem (str, FolderItem.PathTypeURL)
-		    return f
-		    
-		  #else
-		    
-		    #pragma unused absolutePath
-		    
-		  #endif
+		  return FileManager.GetFolderItemFromPOSIXPath( absolutePath )
+		  
 		End Function
 	#tag EndMethod
 

--- a/macoslib/FSEventModule/FSEventStream.rbbas
+++ b/macoslib/FSEventModule/FSEventStream.rbbas
@@ -237,9 +237,9 @@ Class FSEventStream
 		    arp.Append   path
 		    
 		    if RelativeTo<>nil then
-		      f = Cocoa.GetFolderItemFromPOSIXPath( RelativeTo.POSIXPath + "/" + path )
+		      f = GetFolderItemFromPOSIXPath( RelativeTo.POSIXPath + "/" + path )
 		    else
-		      f = Cocoa.GetFolderItemFromPOSIXPath( path )
+		      f = GetFolderItemFromPOSIXPath( path )
 		    end if
 		    
 		    flags = mb2.UInt32Value( i * 4 )

--- a/macoslib/FileManager/FileManager.rbbas
+++ b/macoslib/FileManager/FileManager.rbbas
@@ -120,7 +120,7 @@ Module FileManager
 		          #pragma unused targetName
 		          #pragma unused volumeName
 		        #endif
-		        r = Cocoa.GetFolderItemFromPOSIXPath( pathString )
+		        r = GetFolderItemFromPOSIXPath( pathString )
 		      end if
 		    end if
 		    
@@ -223,6 +223,33 @@ Module FileManager
 		        return nil
 		      end if
 		    end if
+		    
+		  #endif
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Function GetFolderItemFromPOSIXPath(absolutePath as String) As FolderItem
+		  // Note: The passed path must be absolute, i.e. start from root with "/"
+		  
+		  #if TargetMacOS
+		    
+		    declare function CFURLCreateWithFileSystemPath lib CarbonLib (allocator as ptr, filePath as CFStringRef, pathStyle as Integer, isDirectory as Boolean) as Ptr
+		    declare function CFURLGetString lib CarbonLib (anURL as Ptr) as Ptr
+		    declare sub CFRelease lib CarbonLib (cf as Ptr)
+		    declare function CFRetain lib CarbonLib (cf as Ptr) as CFStringRef
+		    
+		    const kCFURLPOSIXPathStyle = 0
+		    
+		    dim url as Ptr = CFURLCreateWithFileSystemPath(nil, absolutePath, kCFURLPOSIXPathStyle, true)
+		    dim str as CFStringRef = CFRetain (CFURLGetString (url))
+		    CFRelease (url)
+		    dim f as FolderItem = GetFolderItem (str, FolderItem.PathTypeURL)
+		    return f
+		    
+		  #else
+		    
+		    #pragma unused absolutePath
 		    
 		  #endif
 		End Function


### PR DESCRIPTION
- Changed constant name in MacSystemProfiler to kSystemProfilerShellPath for clarity.
- Copied GetFolderItemFromPOSIXPath from Cocoa to FileManager and made it Global.
- Deprecated Cocoa.GetFolderItemFromPOSIXPath.
- Updated version to 135.
