### PR TITLE
Revise NSDictionary and NSMutableDictionary

### DIFF
--- a/Additional Modules/Class Extensions/TextAreaExtension.rbbas
+++ b/Additional Modules/Class Extensions/TextAreaExtension.rbbas
@@ -968,7 +968,7 @@ Protected Module TextAreaExtension
 		    
 		    // Reset the color when typing in the field
 		    dim dict as new NSMutableDictionary( tv.TypingAttributes.MutableCopy, NSObject.hasOwnership )
-		    dict.Value( "NSBackgroundColor" ) = NSColor.TextBackgroundColor
+		    dict.Value(new NSString("NSBackgroundColor")) = NSColor.TextBackgroundColor
 		    tv.TypingAttributes = dict
 		    
 		  #else

--- a/Examples/NSWorkspaceEventsExample.rbfrm
+++ b/Examples/NSWorkspaceEventsExample.rbfrm
@@ -167,10 +167,10 @@ End
 		End Sub
 	#tag EndEvent
 	#tag Event
-		Sub NSWorkspaceDidMountNotification(notification as NSNotification, url as CoreFoundation.CFURL, localizedName as String)
+		Sub NSWorkspaceDidMountNotification(notification as NSNotification, url as NSURL, localizedName as String)
 		  
 		  AppendTextBold notification.Name + EndOfLine
-		  AppendText   "New volume “" + localizedName + "” has been mounted at URL " + url.StringValue + EndOfLine + EndOfLine
+		  AppendText   "New volume “" + localizedName + "” has been mounted at URL " + url.AbsoluteString + EndOfLine + EndOfLine
 		End Sub
 	#tag EndEvent
 	#tag Event
@@ -195,17 +195,17 @@ End
 		End Sub
 	#tag EndEvent
 	#tag Event
-		Sub NSWorkspaceWillUnmountNotification(notification as NSNotification, url as CoreFoundation.CFURL, localizedName as String)
+		Sub NSWorkspaceWillUnmountNotification(notification as NSNotification, url as NSURL, localizedName as String)
 		  
 		  AppendTextBold notification.Name + EndOfLine
-		  AppendText   "Volume “" + localizedName + "” at URL " + url.StringValue + " is unmounting" + EndOfLine + EndOfLine
+		  AppendText   "Volume “" + localizedName + "” at URL " + url.AbsoluteString + " is unmounting" + EndOfLine + EndOfLine
 		End Sub
 	#tag EndEvent
 	#tag Event
-		Sub NSWorkspaceDidUnmountNotification(notification as NSNotification, url as CoreFoundation.CFURL, localizedName as String)
+		Sub NSWorkspaceDidUnmountNotification(notification as NSNotification, url as NSURL, localizedName as String)
 		  
 		  AppendTextBold notification.Name + EndOfLine
-		  AppendText   "Volume “" + localizedName + "” previously at URL " + url.StringValue + " is no longer mounted" + EndOfLine + EndOfLine
+		  AppendText   "Volume “" + localizedName + "” previously at URL " + url.AbsoluteString + " is no longer mounted" + EndOfLine + EndOfLine
 		End Sub
 	#tag EndEvent
 	#tag Event
@@ -293,11 +293,11 @@ End
 		End Sub
 	#tag EndEvent
 	#tag Event
-		Sub NSWorkspaceDidRenameVolumeNotification(notification as NSNotification, oldURL as CoreFoundation.CFURL, oldLocalizedName as string, newURL as CoreFoundation.CFURL, newLocalizedName as string)
+		Sub NSWorkspaceDidRenameVolumeNotification(notification as NSNotification, oldURL as NSURL, oldLocalizedName as string, newURL as NSURL, newLocalizedName as string)
 		  
 		  AppendTextBold notification.Name + EndOfLine
-		  AppendText   "Volume “" + oldLocalizedName + "” previously at URL " + oldURL.StringValue + " has been renamed to “"_
-		  + newLocalizedName + "” and mounted at URL " + newURL.StringValue + EndOfLine + EndOfLine
+		  AppendText   "Volume “" + oldLocalizedName + "” previously at URL " + oldURL.AbsoluteString + " has been renamed to “"_
+		  + newLocalizedName + "” and mounted at URL " + newURL.AbsoluteString + EndOfLine + EndOfLine
 		End Sub
 	#tag EndEvent
 #tag EndEvents

--- a/macoslib/Cocoa/NSAttributedString.rbbas
+++ b/macoslib/Cocoa/NSAttributedString.rbbas
@@ -906,729 +906,638 @@ Inherits NSObject
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSAttachmentAttributeName() As String
+		 Shared Function NSAttachmentAttributeName() As Ptr
+		  return ResolveSymbol("NSAttachmentAttributeName")
 		  
-		  return Cocoa.StringConstant("NSAttachmentAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSAuthorDocumentAttribute() As String
-		  
-		  return Cocoa.StringConstant("NSAuthorDocumentAttribute")
+		 Shared Function NSAuthorDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSAuthorDocumentAttribute")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSBackgroundColorAttributeName() As String
+		 Shared Function NSBackgroundColorAttributeName() As Ptr
+		  return ResolveSymbol("NSBackgroundColorAttributeName")
 		  
-		  return Cocoa.StringConstant("NSBackgroundColorAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSBackgroundColorDocumentAttribute() As String
+		 Shared Function NSBackgroundColorDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSBackgroundColorDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSBackgroundColorDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSBaselineOffsetAttributeName() As String
-		  
-		  return Cocoa.StringConstant("NSBaselineOffsetAttributeName")
+		 Shared Function NSBaselineOffsetAttributeName() As Ptr
+		  return ResolveSymbol("NSBaselineOffsetAttributeName")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSBaseURLDocumentOption() As String
+		 Shared Function NSBaseURLDocumentOption() As Ptr
+		  return ResolveSymbol("NSBaseURLDocumentOption")
 		  
-		  return Cocoa.StringConstant("NSBaseURLDocumentOption")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSBottomMarginDocumentAttribute() As String
+		 Shared Function NSBottomMarginDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSBottomMarginDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSBottomMarginDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSCategoryDocumentAttribute() As String
-		  
-		  return Cocoa.StringConstant("NSCategoryDocumentAttribute")
+		 Shared Function NSCategoryDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSCategoryDocumentAttribute")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSCharacterEncodingDocumentAttribute() As String
+		 Shared Function NSCharacterEncodingDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSCharacterEncodingDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSCharacterEncodingDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSCharacterEncodingDocumentOption() As String
+		 Shared Function NSCharacterEncodingDocumentOption() As Ptr
+		  return ResolveSymbol("NSCharacterEncodingDocumentOption")
 		  
-		  return Cocoa.StringConstant("NSCharacterEncodingDocumentOption")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSCharacterShapeAttributeName() As String
-		  
-		  return Cocoa.StringConstant("NSCharacterShapeAttributeName")
+		 Shared Function NSCharacterShapeAttributeName() As Ptr
+		  return ResolveSymbol("NSCharacterShapeAttributeName")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSCocoaVersionDocumentAttribute() As String
+		 Shared Function NSCocoaVersionDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSCocoaVersionDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSCocoaVersionDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSCommentDocumentAttribute() As String
-		  
-		  return Cocoa.StringConstant("NSCommentDocumentAttribute")
+		 Shared Function NSCommentDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSCommentDocumentAttribute")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSCompanyDocumentAttribute() As String
+		 Shared Function NSCompanyDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSCompanyDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSCompanyDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSConvertedDocumentAttribute() As String
+		 Shared Function NSConvertedDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSConvertedDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSConvertedDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSCopyrightDocumentAttribute() As String
-		  
-		  return Cocoa.StringConstant("NSCopyrightDocumentAttribute")
+		 Shared Function NSCopyrightDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSCopyrightDocumentAttribute")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSCreationTimeDocumentAttribute() As String
+		 Shared Function NSCreationTimeDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSCreationTimeDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSCreationTimeDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSCursorAttributeName() As String
+		 Shared Function NSCursorAttributeName() As Ptr
+		  return ResolveSymbol("NSCursorAttributeName")
 		  
-		  return Cocoa.StringConstant("NSCursorAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSDefaultAttributesDocumentOption() As String
-		  
-		  return Cocoa.StringConstant("NSDefaultAttributesDocumentOption")
+		 Shared Function NSDefaultAttributesDocumentOption() As Ptr
+		  return ResolveSymbol("NSDefaultAttributesDocumentOption")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSDefaultTabIntervalDocumentAttribute() As String
+		 Shared Function NSDefaultTabIntervalDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSDefaultTabIntervalDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSDefaultTabIntervalDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSDocFormatTextDocumentType() As String
+		 Shared Function NSDocFormatTextDocumentType() As Ptr
+		  return ResolveSymbol("NSDocFormatTextDocumentType")
 		  
-		  return Cocoa.StringConstant("NSDocFormatTextDocumentType")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSDocumentTypeDocumentAttribute() As String
-		  
-		  return Cocoa.StringConstant("NSDocumentTypeDocumentAttribute")
+		 Shared Function NSDocumentTypeDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSDocumentTypeDocumentAttribute")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSDocumentTypeDocumentOption() As String
+		 Shared Function NSDocumentTypeDocumentOption() As Ptr
+		  return ResolveSymbol("NSDocumentTypeDocumentOption")
 		  
-		  return Cocoa.StringConstant("NSDocumentTypeDocumentOption")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSEditorDocumentAttribute() As String
-		  
-		  return Cocoa.StringConstant("NSEditorDocumentAttribute")
+		 Shared Function NSEditorDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSEditorDocumentAttribute")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSExcludedElementsDocumentAttribute() As String
+		 Shared Function NSExcludedElementsDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSExcludedElementsDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSExcludedElementsDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSExpansionAttributeName() As String
+		 Shared Function NSExpansionAttributeName() As Ptr
+		  return ResolveSymbol("NSExpansionAttributeName")
 		  
-		  return Cocoa.StringConstant("NSExpansionAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSFileTypeDocumentAttribute() As String
-		  
-		  return Cocoa.StringConstant("NSFileTypeDocumentAttribute")
+		 Shared Function NSFileTypeDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSFileTypeDocumentAttribute")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSFileTypeDocumentOption() As String
+		 Shared Function NSFileTypeDocumentOption() As Ptr
+		  return ResolveSymbol("NSFileTypeDocumentOption")
 		  
-		  return Cocoa.StringConstant("NSFileTypeDocumentOption")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSFontAttributeName() As String
+		 Shared Function NSFontAttributeName() As Ptr
+		  return ResolveSymbol("NSFontAttributeName")
 		  
-		  return Cocoa.StringConstant("NSFontAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSForegroundColorAttributeName() As String
-		  
-		  return Cocoa.StringConstant("NSForegroundColorAttributeName")
+		 Shared Function NSForegroundColorAttributeName() As Ptr
+		  return ResolveSymbol("NSForegroundColorAttributeName")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSGlyphInfoAttributeName() As String
+		 Shared Function NSGlyphInfoAttributeName() As Ptr
+		  return ResolveSymbol("NSGlyphInfoAttributeName")
 		  
-		  return Cocoa.StringConstant("NSGlyphInfoAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSHTMLTextDocumentType() As String
+		 Shared Function NSHTMLTextDocumentType() As Ptr
+		  return ResolveSymbol("NSHTMLTextDocumentType")
 		  
-		  return Cocoa.StringConstant("NSHTMLTextDocumentType")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSHyphenationFactorDocumentAttribute() As String
-		  
-		  return Cocoa.StringConstant("NSHyphenationFactorDocumentAttribute")
+		 Shared Function NSHyphenationFactorDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSHyphenationFactorDocumentAttribute")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSKernAttributeName() As String
+		 Shared Function NSKernAttributeName() As Ptr
+		  return ResolveSymbol("NSKernAttributeName")
 		  
-		  return Cocoa.StringConstant("NSKernAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSKeywordsDocumentAttribute() As String
+		 Shared Function NSKeywordsDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSKeywordsDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSKeywordsDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSLeftMarginDocumentAttribute() As String
-		  
-		  return Cocoa.StringConstant("NSLeftMarginDocumentAttribute")
+		 Shared Function NSLeftMarginDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSLeftMarginDocumentAttribute")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSLigatureAttributeName() As String
+		 Shared Function NSLigatureAttributeName() As Ptr
+		  return ResolveSymbol("NSLigatureAttributeName")
 		  
-		  return Cocoa.StringConstant("NSLigatureAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSLinkAttributeName() As String
+		 Shared Function NSLinkAttributeName() As Ptr
+		  return ResolveSymbol("NSLinkAttributeName")
 		  
-		  return Cocoa.StringConstant("NSLinkAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSMacSimpleTextDocumentType() As String
-		  
-		  return Cocoa.StringConstant("NSMacSimpleTextDocumentType")
+		 Shared Function NSMacSimpleTextDocumentType() As Ptr
+		  return ResolveSymbol("NSMacSimpleTextDocumentType")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSManagerDocumentAttribute() As String
+		 Shared Function NSManagerDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSManagerDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSManagerDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSMarkedClauseSegmentAttributeName() As String
+		 Shared Function NSMarkedClauseSegmentAttributeName() As Ptr
+		  return ResolveSymbol("NSMarkedClauseSegmentAttributeName")
 		  
-		  return Cocoa.StringConstant("NSMarkedClauseSegmentAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSModificationTimeDocumentAttribute() As String
-		  
-		  return Cocoa.StringConstant("NSModificationTimeDocumentAttribute")
+		 Shared Function NSModificationTimeDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSModificationTimeDocumentAttribute")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSObliquenessAttributeName() As String
+		 Shared Function NSObliquenessAttributeName() As Ptr
+		  return ResolveSymbol("NSObliquenessAttributeName")
 		  
-		  return Cocoa.StringConstant("NSObliquenessAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSOfficeOpenXMLTextDocumentType() As String
+		 Shared Function NSOfficeOpenXMLTextDocumentType() As Ptr
+		  return ResolveSymbol("NSOfficeOpenXMLTextDocumentType")
 		  
-		  return Cocoa.StringConstant("NSOfficeOpenXMLTextDocumentType")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSOpenDocumentTextDocumentType() As String
-		  
-		  return Cocoa.StringConstant("NSOpenDocumentTextDocumentType")
+		 Shared Function NSOpenDocumentTextDocumentType() As Ptr
+		  return ResolveSymbol("NSOpenDocumentTextDocumentType")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSPaperSizeDocumentAttribute() As String
+		 Shared Function NSPaperSizeDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSPaperSizeDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSPaperSizeDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSParagraphStyleAttributeName() As String
-		  
-		  return Cocoa.StringConstant("NSParagraphStyleAttributeName")
+		 Shared Function NSParagraphStyleAttributeName() As Ptr
+		  return ResolveSymbol("NSParagraphStyleAttributeName")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSPlainTextDocumentType() As String
+		 Shared Function NSPlainTextDocumentType() As Ptr
+		  return ResolveSymbol("NSPlainTextDocumentType")
 		  
-		  return Cocoa.StringConstant("NSPlainTextDocumentType")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSPrefixSpacesDocumentAttribute() As String
+		 Shared Function NSPrefixSpacesDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSPrefixSpacesDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSPrefixSpacesDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSReadOnlyDocumentAttribute() As String
-		  
-		  return Cocoa.StringConstant("NSReadOnlyDocumentAttribute")
+		 Shared Function NSReadOnlyDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSReadOnlyDocumentAttribute")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSRightMarginDocumentAttribute() As String
+		 Shared Function NSRightMarginDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSRightMarginDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSRightMarginDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSRTFDTextDocumentType() As String
+		 Shared Function NSRTFDTextDocumentType() As Ptr
+		  return ResolveSymbol("NSRTFDTextDocumentType")
 		  
-		  return Cocoa.StringConstant("NSRTFDTextDocumentType")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSRTFTextDocumentType() As String
-		  
-		  return Cocoa.StringConstant("NSRTFTextDocumentType")
+		 Shared Function NSRTFTextDocumentType() As Ptr
+		  return ResolveSymbol("NSRTFTextDocumentType")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSShadowAttributeName() As String
+		 Shared Function NSShadowAttributeName() As Ptr
+		  return ResolveSymbol("NSShadowAttributeName")
 		  
-		  return Cocoa.StringConstant("NSShadowAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSSpellingStateAttributeName() As String
+		 Shared Function NSSpellingStateAttributeName() As Ptr
+		  return ResolveSymbol("NSSpellingStateAttributeName")
 		  
-		  return Cocoa.StringConstant("NSSpellingStateAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSStrikethroughColorAttributeName() As String
-		  
-		  return Cocoa.StringConstant("NSStrikethroughColorAttributeName")
+		 Shared Function NSStrikethroughColorAttributeName() As Ptr
+		  return ResolveSymbol("NSStrikethroughColorAttributeName")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSStrikethroughStyleAttributeName() As String
+		 Shared Function NSStrikethroughStyleAttributeName() As Ptr
+		  return ResolveSymbol("NSStrikethroughStyleAttributeName")
 		  
-		  return Cocoa.StringConstant("NSStrikethroughStyleAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSStrokeColorAttributeName() As String
+		 Shared Function NSStrokeColorAttributeName() As Ptr
+		  return ResolveSymbol("NSStrokeColorAttributeName")
 		  
-		  return Cocoa.StringConstant("NSStrokeColorAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSStrokeWidthAttributeName() As String
-		  
-		  return Cocoa.StringConstant("NSStrokeWidthAttributeName")
+		 Shared Function NSStrokeWidthAttributeName() As Ptr
+		  return ResolveSymbol("NSStrokeWidthAttributeName")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSSubjectDocumentAttribute() As String
+		 Shared Function NSSubjectDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSSubjectDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSSubjectDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSSuperscriptAttributeName() As String
+		 Shared Function NSSuperscriptAttributeName() As Ptr
+		  return ResolveSymbol("NSSuperscriptAttributeName")
 		  
-		  return Cocoa.StringConstant("NSSuperscriptAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSTextEncodingNameDocumentAttribute() As String
-		  
-		  return Cocoa.StringConstant("NSTextEncodingNameDocumentAttribute")
+		 Shared Function NSTextEncodingNameDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSTextEncodingNameDocumentAttribute")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSTextEncodingNameDocumentOption() As String
+		 Shared Function NSTextEncodingNameDocumentOption() As Ptr
+		  return ResolveSymbol("NSTextEncodingNameDocumentOption")
 		  
-		  return Cocoa.StringConstant("NSTextEncodingNameDocumentOption")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSTextLayoutSectionOrientation() As String
+		 Shared Function NSTextLayoutSectionOrientation() As Ptr
+		  return ResolveSymbol("NSTextLayoutSectionOrientation")
 		  
-		  return Cocoa.StringConstant("NSTextLayoutSectionOrientation")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSTextLayoutSectionRange() As String
-		  
-		  return Cocoa.StringConstant("NSTextLayoutSectionRange")
+		 Shared Function NSTextLayoutSectionRange() As Ptr
+		  return ResolveSymbol("NSTextLayoutSectionRange")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSTextLayoutSectionsAttribute() As String
+		 Shared Function NSTextLayoutSectionsAttribute() As Ptr
+		  return ResolveSymbol("NSTextLayoutSectionsAttribute")
 		  
-		  return Cocoa.StringConstant("NSTextLayoutSectionsAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSTextSizeMultiplierDocumentOption() As String
+		 Shared Function NSTextSizeMultiplierDocumentOption() As Ptr
+		  return ResolveSymbol("NSTextSizeMultiplierDocumentOption")
 		  
-		  return Cocoa.StringConstant("NSTextSizeMultiplierDocumentOption")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSTimeoutDocumentOption() As String
-		  
-		  return Cocoa.StringConstant("NSTimeoutDocumentOption")
+		 Shared Function NSTimeoutDocumentOption() As Ptr
+		  return ResolveSymbol("NSTimeoutDocumentOption")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSTitleDocumentAttribute() As String
+		 Shared Function NSTitleDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSTitleDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSTitleDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSToolTipAttributeName() As String
-		  
-		  return Cocoa.StringConstant("NSToolTipAttributeName")
+		 Shared Function NSToolTipAttributeName() As Ptr
+		  return ResolveSymbol("NSToolTipAttributeName")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSTopMarginDocumentAttribute() As String
+		 Shared Function NSTopMarginDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSTopMarginDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSTopMarginDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSUnderlineColorAttributeName() As String
+		 Shared Function NSUnderlineColorAttributeName() As Ptr
+		  return ResolveSymbol("NSUnderlineColorAttributeName")
 		  
-		  return Cocoa.StringConstant("NSUnderlineColorAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSUnderlinePatternDash() As String
-		  
-		  return Cocoa.StringConstant("NSUnderlinePatternDash")
+		 Shared Function NSUnderlinePatternDash() As Ptr
+		  return ResolveSymbol("NSUnderlinePatternDash")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSUnderlinePatternDashDot() As String
+		 Shared Function NSUnderlinePatternDashDot() As Ptr
+		  return ResolveSymbol("NSUnderlinePatternDashDot")
 		  
-		  return Cocoa.StringConstant("NSUnderlinePatternDashDot")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSUnderlinePatternDashDotDot() As String
+		 Shared Function NSUnderlinePatternDashDotDot() As Ptr
+		  return ResolveSymbol("NSUnderlinePatternDashDotDot")
 		  
-		  return Cocoa.StringConstant("NSUnderlinePatternDashDotDot")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSUnderlinePatternDot() As String
-		  
-		  return Cocoa.StringConstant("NSUnderlinePatternDot")
+		 Shared Function NSUnderlinePatternDot() As Ptr
+		  return ResolveSymbol("NSUnderlinePatternDot")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSUnderlinePatternSolid() As String
+		 Shared Function NSUnderlinePatternSolid() As Ptr
+		  return ResolveSymbol("NSUnderlinePatternSolid")
 		  
-		  return Cocoa.StringConstant("NSUnderlinePatternSolid")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSUnderlineStyleAttributeName() As String
+		 Shared Function NSUnderlineStyleAttributeName() As Ptr
+		  return ResolveSymbol("NSUnderlineStyleAttributeName")
 		  
-		  return Cocoa.StringConstant("NSUnderlineStyleAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSUnderlineStyleDouble() As String
-		  
-		  return Cocoa.StringConstant("NSUnderlineStyleDouble")
+		 Shared Function NSUnderlineStyleDouble() As Ptr
+		  return ResolveSymbol("NSUnderlineStyleDouble")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSUnderlineStyleNone() As String
+		 Shared Function NSUnderlineStyleNone() As Ptr
+		  return ResolveSymbol("NSUnderlineStyleNone")
 		  
-		  return Cocoa.StringConstant("NSUnderlineStyleNone")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSUnderlineStyleSingle() As String
+		 Shared Function NSUnderlineStyleSingle() As Ptr
+		  return ResolveSymbol("NSUnderlineStyleSingle")
 		  
-		  return Cocoa.StringConstant("NSUnderlineStyleSingle")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSUnderlineStyleThick() As String
-		  
-		  return Cocoa.StringConstant("NSUnderlineStyleThick")
+		 Shared Function NSUnderlineStyleThick() As Ptr
+		  return ResolveSymbol("NSUnderlineStyleThick")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSVerticalGlyphFormAttributeName() As String
+		 Shared Function NSVerticalGlyphFormAttributeName() As Ptr
+		  return ResolveSymbol("NSVerticalGlyphFormAttributeName")
 		  
-		  return Cocoa.StringConstant("NSVerticalGlyphFormAttributeName")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSViewModeDocumentAttribute() As String
+		 Shared Function NSViewModeDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSViewModeDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSViewModeDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSViewSizeDocumentAttribute() As String
-		  
-		  return Cocoa.StringConstant("NSViewSizeDocumentAttribute")
+		 Shared Function NSViewSizeDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSViewSizeDocumentAttribute")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSViewZoomDocumentAttribute() As String
+		 Shared Function NSViewZoomDocumentAttribute() As Ptr
+		  return ResolveSymbol("NSViewZoomDocumentAttribute")
 		  
-		  return Cocoa.StringConstant("NSViewZoomDocumentAttribute")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSWebArchiveTextDocumentType() As String
+		 Shared Function NSWebArchiveTextDocumentType() As Ptr
+		  return ResolveSymbol("NSWebArchiveTextDocumentType")
 		  
-		  return Cocoa.StringConstant("NSWebArchiveTextDocumentType")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSWebPreferencesDocumentOption() As String
-		  
-		  return Cocoa.StringConstant("NSWebPreferencesDocumentOption")
+		 Shared Function NSWebPreferencesDocumentOption() As Ptr
+		  return ResolveSymbol("NSWebPreferencesDocumentOption")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSWebResourceLoadDelegateDocumentOption() As String
+		 Shared Function NSWebResourceLoadDelegateDocumentOption() As Ptr
+		  return ResolveSymbol("NSWebResourceLoadDelegateDocumentOption")
 		  
-		  return Cocoa.StringConstant("NSWebResourceLoadDelegateDocumentOption")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSWordMLTextDocumentType() As String
+		 Shared Function NSWordMLTextDocumentType() As Ptr
+		  return ResolveSymbol("NSWordMLTextDocumentType")
 		  
-		  return Cocoa.StringConstant("NSWordMLTextDocumentType")
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSWritingDirectionAttributeName() As String
-		  
-		  return Cocoa.StringConstant("NSWritingDirectionAttributeName")
+		 Shared Function NSWritingDirectionAttributeName() As Ptr
+		  return ResolveSymbol("NSWritingDirectionAttributeName")
 		  
 		End Function
 	#tag EndMethod
@@ -1682,149 +1591,10 @@ Inherits NSObject
 		End Function
 	#tag EndMethod
 
-	#tag Method, Flags = &h0
-		 Shared Function QuickCreate(text as string, baseStyles as NSDictionary, paramarray styles as Tuple) As NSAttributedString
-		  
-		  dim nsdict as NSMutableDictionary
-		  dim result as NSAttributedString
-		  
-		  nsdict = StyleDictionaryFromTuples( styles, baseStyles )
-		  
-		  'if baseStyles<>nil then
-		  'nsdict = new NSMutableDictionary( baseStyles.MutableCopy, true )
-		  'else
-		  'nsdict = new NSMutableDictionary
-		  'end if
-		  '
-		  'for i as integer=0 to styles.Ubound
-		  't = styles( i )
-		  '
-		  'select case t(0)
-		  'case "font"
-		  'dim fontfamily as string
-		  'dim isBold as Boolean
-		  'dim isItalic as Boolean
-		  'dim textColor as color = &c000000
-		  'dim size as double = 12.0
-		  'dim nsf as NSFont
-		  'dim IsSuperScript as Boolean
-		  'dim IsSubscript as Boolean
-		  '
-		  'for j = 1 to t.Count - 1
-		  'select case Vartype( t(j))
-		  'case Variant.TypeString
-		  'select case t(j)
-		  'case "bold"
-		  'isBold = true
-		  'case "italic"
-		  'isItalic = true
-		  'case "sup", "super", "superscript"
-		  'IsSuperScript = true
-		  'case "sub", "subscript"
-		  'IsSubscript = true
-		  'else
-		  'fontfamily = t(j)
-		  'end select
-		  'case Variant.TypeInteger, Variant.TypeDouble
-		  'size = t(j)
-		  'case Variant.TypeColor
-		  'textColor = t(j)
-		  'else
-		  '
-		  'end select
-		  'next
-		  '
-		  'nsf = NSFontManager.SharedManager.GetFont( fontfamily, size, isBold, isItalic )
-		  'nsdict.Value( Cocoa.StringConstant( "NSFontAttributeName" )) = nsf
-		  'nsdict.Value( Cocoa.StringConstant( "NSForegroundColorAttributeName" )) = new NSColor( textColor )
-		  '
-		  'case "underline", "strikethrough"
-		  'dim underlineStyle as integer
-		  'dim underlineColor as Color
-		  'dim hasUnderlineColor as Boolean
-		  'dim underlinePattern as integer
-		  'dim underlineByWord as Boolean //Mask = 32768, i.e. &h8000
-		  'dim StyleValue as integer
-		  '
-		  'for j = 1 to t.Count - 1
-		  'select case Vartype( t(j))
-		  'case Variant.TypeString
-		  'select case t(j)
-		  'case "single"
-		  'underlineStyle = 1
-		  'case "thick"
-		  'underlineStyle = 2
-		  'case "double"
-		  'underlineStyle = 9
-		  'case "solid"
-		  'underlinePattern = 0
-		  'case "dash"
-		  'underlinePattern = &h200
-		  'case "dashdot"
-		  'underlinePattern = &h300
-		  'case "dashdotdot"
-		  'underlinePattern = &h400
-		  'case "dot"
-		  'underlinePattern = &h100
-		  'case "byword"
-		  'underlineByWord = true
-		  'end select
-		  '
-		  'case Variant.TypeColor
-		  'underlineColor = t(j)
-		  'hasUnderlineColor = true
-		  'else
-		  '
-		  'end select
-		  'next
-		  '
-		  'StyleValue = underlineStyle OR underlinePattern
-		  'if underlineByWord then
-		  'StyleValue = StyleValue OR &h8000
-		  'end if
-		  'if t(0)="underline" then
-		  'nsdict.Value( Cocoa.StringConstant( "NSUnderlineStyleAttributeName" )) = new NSNumber( StyleValue )
-		  'else
-		  'nsdict.Value( Cocoa.StringConstant( "NSStrikethroughStyleAttributeName" )) = new NSNumber( StyleValue )
-		  'end if
-		  '
-		  'if hasUnderlineColor then
-		  'if t(0)="underline" then
-		  'nsdict.Value( Cocoa.StringConstant( "NSUnderlineColorAttributeName" )) = new NSColor( underlineColor )
-		  'else
-		  'nsdict.Value( Cocoa.StringConstant( "NSStrikethroughColorAttributeName" )) = new NSColor( underlineColor )
-		  'end if
-		  'end if
-		  '
-		  'case "link"
-		  'nsdict.Value( Cocoa.StringConstant( "NSLinkAttributeName" )) = NSString( t(1))
-		  '
-		  'case "tooltip"
-		  'nsdict.Value( Cocoa.StringConstant( "NSToolTipAttributeName" )) = NSString( t(1))
-		  '
-		  'case "spacing"
-		  '
-		  'else
-		  '
-		  'end select
-		  '
-		  'next
-		  '
-		  'nsdict.Value( Cocoa.StringConstant( "NSParagraphStyleAttributeName" )) = NSParagraphStyle.Default
-		  '
-		  result = NSAttributedString.CreateFromString_WithAttributes( text, nsdict )
-		  if nsdict.HasKey(new NSString( "macoslibSuperScript" )) OR nsdict.HasKey(new NSString( "macoslibSubScript" )) then
-		    dim nsmas as NSMutableAttributedString = new NSMutableAttributedString( result.MutableCopy, true )
-		    if nsdict.HasKey(new NSString( "macoslibSuperScript" )) then
-		      nsmas.Superscript()
-		    else //Cannot be both true
-		      nsmas.Subscript()
-		    end if
-		    
-		    result = nsmas
-		  end if
-		  
-		  return  result
+	#tag Method, Flags = &h21
+		Private Shared Function ResolveSymbol(name as String) As Ptr
+		  dim b as CFBundle = CFBundle.NewCFBundleFromID("com.apple.Cocoa")
+		  return b.DataPointerNotRetained(name)
 		End Function
 	#tag EndMethod
 
@@ -2002,152 +1772,6 @@ Inherits NSObject
 		    #pragma unused longestEffectiveRange
 		    #pragma unused rangeLimit
 		  #endif
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h0
-		 Shared Function StyleDictionaryFromTuples(baseStyles as NSDictionary = nil, paramarray styles() as Tuple) As NSMutableDictionary
-		  return StyleDictionaryFromTuples( styles, baseStyles )
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h0
-		 Shared Function StyleDictionaryFromTuples(styles() as Tuple, baseStyles as NSDictionary = nil) As NSMutableDictionary
-		  dim t as Tuple
-		  dim j as integer
-		  'dim nsps as NSParagraphStyle
-		  dim nsdict as NSMutableDictionary
-		  
-		  if baseStyles<>nil then
-		    nsdict = new NSMutableDictionary( baseStyles.MutableCopy, true )
-		  else
-		    nsdict = new NSMutableDictionary
-		  end if
-		  
-		  for i as integer=0 to styles.Ubound
-		    t = styles( i )
-		    
-		    select case t(0)
-		    case "font"
-		      dim fontfamily as string
-		      dim isBold as Boolean
-		      dim isItalic as Boolean
-		      dim textColor as color = &c000000
-		      dim size as double = 12.0
-		      dim nsf as NSFont
-		      dim IsSuperScript as Boolean
-		      dim IsSubscript as Boolean
-		      
-		      for j = 1 to t.Count - 1
-		        select case Vartype( t(j))
-		        case Variant.TypeString
-		          select case t(j)
-		          case "bold"
-		            isBold = true
-		          case "italic"
-		            isItalic = true
-		          case "sup", "super", "superscript"
-		            IsSuperScript = true
-		          case "sub", "subscript"
-		            IsSubscript = true
-		          else
-		            fontfamily = t(j)
-		          end select
-		        case Variant.TypeInteger, Variant.TypeDouble
-		          size = t(j)
-		        case Variant.TypeColor
-		          textColor = t(j)
-		        else
-		          
-		        end select
-		      next
-		      
-		      nsf = NSFontManager.SharedManager.GetFont( fontfamily, size, isBold, isItalic )
-		      nsdict.Value( Cocoa.StringConstant( "NSFontAttributeName" )) = nsf
-		      nsdict.Value( Cocoa.StringConstant( "NSForegroundColorAttributeName" )) = new NSColor( textColor )
-		      
-		      if IsSuperscript then
-		        nsdict.Value( "macoslibSuperScript" ) = new  NSNumber( true )
-		      else //Cannot be both true
-		        nsdict.Value( "macoslibSubScript" ) = new  NSNumber( true )
-		      end if
-		      
-		    case "underline", "strikethrough"
-		      dim underlineStyle as integer
-		      dim underlineColor as Color
-		      dim hasUnderlineColor as Boolean
-		      dim underlinePattern as integer
-		      dim underlineByWord as Boolean //Mask = 32768, i.e. &h8000
-		      dim StyleValue as integer
-		      
-		      for j = 1 to t.Count - 1
-		        select case Vartype( t(j))
-		        case Variant.TypeString
-		          select case t(j)
-		          case "single"
-		            underlineStyle = 1
-		          case "thick"
-		            underlineStyle = 2
-		          case "double"
-		            underlineStyle = 9
-		          case "solid"
-		            underlinePattern = 0
-		          case "dash"
-		            underlinePattern = &h200
-		          case "dashdot"
-		            underlinePattern = &h300
-		          case "dashdotdot"
-		            underlinePattern = &h400
-		          case "dot"
-		            underlinePattern = &h100
-		          case "byword"
-		            underlineByWord = true
-		          end select
-		          
-		        case Variant.TypeColor
-		          underlineColor = t(j)
-		          hasUnderlineColor = true
-		        else
-		          
-		        end select
-		      next
-		      
-		      StyleValue = underlineStyle OR underlinePattern
-		      if underlineByWord then
-		        StyleValue = StyleValue OR &h8000
-		      end if
-		      if t(0)="underline" then
-		        nsdict.Value( Cocoa.StringConstant( "NSUnderlineStyleAttributeName" )) = new NSNumber( StyleValue )
-		      else
-		        nsdict.Value( Cocoa.StringConstant( "NSStrikethroughStyleAttributeName" )) = new NSNumber( StyleValue )
-		      end if
-		      
-		      if hasUnderlineColor then
-		        if t(0)="underline" then
-		          nsdict.Value( Cocoa.StringConstant( "NSUnderlineColorAttributeName" )) = new NSColor( underlineColor )
-		        else
-		          nsdict.Value( Cocoa.StringConstant( "NSStrikethroughColorAttributeName" )) = new NSColor( underlineColor )
-		        end if
-		      end if
-		      
-		    case "link"
-		      nsdict.Value( Cocoa.StringConstant( "NSLinkAttributeName" )) = NSString( t(1))
-		      
-		    case "tooltip"
-		      nsdict.Value( Cocoa.StringConstant( "NSToolTipAttributeName" )) = NSString( t(1))
-		      
-		    case "spacing"
-		      
-		    else
-		      
-		    end select
-		    
-		  next
-		  
-		  nsdict.Value( Cocoa.StringConstant( "NSParagraphStyleAttributeName" )) = NSParagraphStyle.Default
-		  
-		  
-		  return  nsdict
 		End Function
 	#tag EndMethod
 

--- a/macoslib/Cocoa/NSMutableDictionary.rbbas
+++ b/macoslib/Cocoa/NSMutableDictionary.rbbas
@@ -1,41 +1,21 @@
 #tag Class
 Class NSMutableDictionary
 Inherits NSDictionary
-	#tag Method, Flags = &h1000
-		Sub Add(otherDictionary as NSDictionary)
-		  
-		  #if targetMacOS
-		    declare sub addEntriesFromDictionary lib CocoaLib selector "addEntriesFromDictionary:" (obj_id as Ptr, otherDictionary as Ptr)
-		    
-		    if otherDictionary <> nil then
-		      addEntriesFromDictionary self, otherDictionary
-		    end if
-		    
-		  #else
-		    #pragma unused otherDictionary
-		  #endif
-		  
-		End Sub
-	#tag EndMethod
-
 	#tag Method, Flags = &h0
-		Sub AppendDictionary(dictToAppend as NSDictionary)
+		Sub AddEntries(d as NSDictionary)
 		  
 		  #if TargetMacOS
 		    declare sub addEntriesFromDictionary lib Cocoalib selector "addEntriesFromDictionary:" ( id as Ptr, value as Ptr )
 		    
-		    addEntriesFromDictionary( me.id, dictToAppend.id )
+		    if d is nil then
+		      dim e as new NilObjectException
+		      e.Message = CurrentMethodName + ": d cannot be nil."
+		      raise e
+		    end if
+		    
+		    addEntriesFromDictionary(self, d)
 		  #endif
 		End Sub
-	#tag EndMethod
-
-	#tag Method, Flags = &h21
-		Private Shared Function ClassRef() As Ptr
-		  
-		  static ref as Ptr = Cocoa.NSClassFromString("NSMutableDictionary")
-		  return ref
-		  
-		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
@@ -45,268 +25,20 @@ Inherits NSDictionary
 		  #if TargetMacOS
 		    declare sub removeAllObjects lib CocoaLib selector "removeAllObjects" (id as Ptr)
 		    
-		    removeAllObjects   me.id
+		    removeAllObjects(self)
 		  #endif
 		End Sub
 	#tag EndMethod
 
 	#tag Method, Flags = &h1000
-		Sub Constructor()
+		Sub Constructor(capacity as Integer =20)
 		  #if TargetMacOS
 		    declare function dictionaryWithCapacity lib CocoaLib selector "dictionaryWithCapacity:" ( cls as Ptr, capacity as UInt32 ) as Ptr
 		    
-		    Super.Constructor( dictionaryWithCapacity( Cocoa.NSClassFromString( "NSMutableDictionary" ), 20 ), false )
+		    Super.Constructor(dictionaryWithCapacity(Cocoa.NSClassFromString( "NSMutableDictionary" ), capacity))
 		  #endif
 		  
 		End Sub
-	#tag EndMethod
-
-	#tag Method, Flags = &h1000
-		Sub Constructor(file as FolderItem)
-		  
-		  #if targetMacOS
-		    declare function initWithContentsOfFile lib CocoaLib selector "initWithContentsOfFile:" (obj_id as Ptr, path as CFStringRef) as Ptr
-		    
-		    super.Constructor(initWithContentsOfFile(Allocate("NSMutableDictionary"), file.POSIXPath), NSMutableDictionary.hasOwnership)
-		    
-		  #else
-		    #pragma unused file
-		  #endif
-		  
-		End Sub
-	#tag EndMethod
-
-	#tag Method, Flags = &h1000
-		Sub Constructor(otherDictionary as NSDictionary)
-		  
-		  #if targetMacOS
-		    declare function initWithDictionary lib CocoaLib selector "initWithDictionary:" (obj_id as Ptr, otherDictionary as Ptr) as Ptr
-		    
-		    super.Constructor(initWithDictionary(Allocate("NSMutableDictionary"), otherDictionary), NSMutableDictionary.hasOwnership)
-		    
-		  #else
-		    #pragma unused otherDictionary
-		  #endif
-		  
-		End Sub
-	#tag EndMethod
-
-	#tag Method, Flags = &h1000
-		Sub Constructor(otherDictionary as NSDictionary, copyItems as Boolean)
-		  
-		  #if targetMacOS
-		    declare function initWithDictionary lib CocoaLib selector "initWithDictionary:copyItems:" (obj_id as Ptr, otherDictionary as Ptr, flag as Boolean) as Ptr
-		    
-		    super.Constructor(initWithDictionary(Allocate("NSMutableDictionary"), otherDictionary, copyItems), NSMutableDictionary.hasOwnership)
-		    
-		  #else
-		    #pragma unused otherDictionary
-		    #pragma unused copyItems
-		  #endif
-		  
-		End Sub
-	#tag EndMethod
-
-	#tag Method, Flags = &h1000
-		Sub Constructor(keys() as NSObject, objects() as NSObject)
-		  
-		  #if targetMacOS
-		    declare function initWithObjects lib CocoaLib selector "initWithObjects:forKeys:" (obj_id as Ptr, objects as Ptr, keys as Ptr) as Ptr
-		    
-		    dim keysArray as new NSArray(keys)
-		    dim objectsArray as new NSArray(objects)
-		    
-		    super.Constructor(initWithObjects(Allocate("NSMutableDictionary"), objectsArray, keysArray), NSMutableDictionary.hasOwnership)
-		    
-		  #else
-		    #pragma unused keys
-		    #pragma unused objects
-		  #endif
-		  
-		End Sub
-	#tag EndMethod
-
-	#tag Method, Flags = &h1000
-		Sub Constructor(aURL as NSURL)
-		  
-		  #if targetMacOS
-		    declare function initWithContentsOfURL lib CocoaLib selector "initWithContentsOfURL:" (obj_id as Ptr, aURL as Ptr) as Ptr
-		    
-		    super.Constructor(initWithContentsOfURL(Allocate("NSMutableDictionary"), aURL), NSMutableDictionary.hasOwnership)
-		    
-		  #else
-		    #pragma unused aURL
-		  #endif
-		  
-		End Sub
-	#tag EndMethod
-
-	#tag Method, Flags = &h1000
-		Sub Constructor(numItems as UInt32)
-		  
-		  #if targetMacOS
-		    declare function initWithCapacity lib CocoaLib selector "initWithCapacity:" (obj_id as Ptr, numItems as UInt32) as Ptr
-		    
-		    super.Constructor(initWithCapacity(Allocate("NSMutableDictionary"), numItems), NSMutableDictionary.hasOwnership)
-		    
-		  #else
-		    #pragma unused numItems
-		  #endif
-		  
-		End Sub
-	#tag EndMethod
-
-	#tag Method, Flags = &h1000
-		 Shared Function Create() As NSMutableDictionary
-		  
-		  #if TargetMacOS
-		    declare function dictionary_ lib CocoaLib selector "dictionary" (class_id as Ptr) as Ptr
-		    
-		    dim dictRef as Ptr = dictionary_(ClassRef)
-		    if dictRef <> nil then
-		      return new NSMutableDictionary(dictRef)
-		    else
-		      return nil
-		    end if
-		    
-		  #endif
-		  
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h1000
-		 Shared Function CreateWithCapacity(numItems as UInt32) As NSMutableDictionary
-		  
-		  #if TargetMacOS
-		    declare function dictionaryWithCapacity lib CocoaLib selector "dictionaryWithCapacity:" (class_id as Ptr, numItems as UInt32) as Ptr
-		    
-		    dim dictRef as Ptr = dictionaryWithCapacity(ClassRef, numItems)
-		    if dictRef <> nil then
-		      return new NSMutableDictionary(dictRef)
-		    else
-		      return nil
-		    end if
-		    
-		  #else
-		    #pragma unused numItems
-		  #endif
-		  
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h1000
-		 Shared Function CreateWithDictionary(otherDictionary as NSDictionary) As NSMutableDictionary
-		  
-		  #if TargetMacOS
-		    declare function dictionaryWithDictionary lib CocoaLib selector "dictionaryWithDictionary:" _
-		    (class_id as Ptr, otherDictionary as Ptr) as Ptr
-		    
-		    if otherDictionary <> nil then
-		      dim dictRef as Ptr = dictionaryWithDictionary(ClassRef, otherDictionary)
-		      if dictRef <> nil then
-		        return new NSMutableDictionary(dictRef)
-		      end if
-		    end if
-		    
-		  #else
-		    #pragma unused otherDictionary
-		  #endif
-		  
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h1000
-		 Shared Function CreateWithFile(file as FolderItem) As NSMutableDictionary
-		  
-		  #if TargetMacOS
-		    declare function dictionaryWithContentsOfFile lib CocoaLib selector "dictionaryWithContentsOfFile:" _
-		    (class_id as Ptr, path as CFStringRef) as Ptr
-		    
-		    if file <> nil then
-		      dim dictRef as Ptr = dictionaryWithContentsOfFile(ClassRef, file.POSIXPath)
-		      if dictRef <> nil then
-		        return new NSMutableDictionary(dictRef)
-		      end if
-		    end if
-		    
-		  #else
-		    #pragma unused file
-		  #endif
-		  
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h1000
-		 Shared Function CreateWithObject(key as Ptr, anObject as Ptr) As NSMutableDictionary
-		  
-		  #if TargetMacOS
-		    declare function dictionaryWithObject lib CocoaLib selector "dictionaryWithObject:forKey:" _
-		    (class_id as Ptr, anObject as Ptr, key as Ptr) as Ptr
-		    
-		    dim dictRef as Ptr = dictionaryWithObject(ClassRef, anObject, key)
-		    if dictRef <> nil then
-		      return new NSMutableDictionary(dictRef)
-		    end if
-		    
-		  #else
-		    #pragma unused key
-		    #pragma unused anObject
-		  #endif
-		  
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h1000
-		 Shared Function CreateWithObjects(keys() as NSObject, objects() as NSObject) As NSMutableDictionary
-		  
-		  #if TargetMacOS
-		    declare function dictionaryWithObjects lib CocoaLib selector "dictionaryWithObjects:forKeys:" _
-		    (class_id as Ptr, objects as Ptr, keys as Ptr) as Ptr
-		    
-		    dim keysArray as new NSArray(keys)
-		    dim objectsArray as new NSArray(objects)
-		    
-		    dim dictRef as Ptr = dictionaryWithObjects(ClassRef, objectsArray, keysArray)
-		    if dictRef <> nil then
-		      return new NSMutableDictionary(dictRef)
-		    end if
-		    
-		  #else
-		    #pragma unused keys
-		    #pragma unused objects
-		  #endif
-		  
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h1000
-		 Shared Function CreateWithURL(aURL as NSURL) As NSMutableDictionary
-		  
-		  #if TargetMacOS
-		    declare function dictionaryWithContentsOfURL lib CocoaLib selector "dictionaryWithContentsOfURL:" _
-		    (class_id as Ptr, aURL as Ptr) as Ptr
-		    
-		    if aURL <> nil then
-		      dim dictRef as Ptr = dictionaryWithContentsOfURL(ClassRef, aURL)
-		      if dictRef <> nil then
-		        return new NSMutableDictionary(dictRef)
-		      end if
-		    end if
-		    
-		  #else
-		    #pragma unused aURL
-		  #endif
-		  
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h0
-		Function Operator_Add(otherDictionary as NSDictionary) As NSDictionary
-		  
-		  self.Add otherDictionary
-		  return self
-		  
-		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h1000
@@ -317,6 +49,8 @@ Inherits NSDictionary
 		    
 		    if keys <> nil then
 		      removeObjectsForKeys self, keys
+		    else
+		      //no-op?
 		    end if
 		    
 		  #else
@@ -326,20 +60,8 @@ Inherits NSDictionary
 		End Sub
 	#tag EndMethod
 
-	#tag Method, Flags = &h0
-		Sub Remove(key as NSObject)
-		  
-		  #if TargetMacos
-		    declare sub removeObjectForKey lib CocoaLib selector "removeObjectForKey:" ( id as Ptr, key as Ptr )
-		    
-		    removeObjectForKey   me.id, key.id
-		  #endif
-		End Sub
-	#tag EndMethod
-
 	#tag Method, Flags = &h1000
 		Sub Remove(key as Ptr)
-		  
 		  #if targetMacOS
 		    declare sub removeObjectForKey lib CocoaLib selector "removeObjectForKey:" (obj_id as Ptr, key as Ptr)
 		    
@@ -373,6 +95,8 @@ Inherits NSDictionary
 		    
 		    if otherDictionary <> nil then
 		      setDictionary self, otherDictionary
+		    else
+		      //was this intended to be a no-op?  
 		    end if
 		    
 		  #else
@@ -383,68 +107,13 @@ Inherits NSDictionary
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Value(key as variant, assigns newValue as NSObject)
+		Sub Value(key as Ptr, assigns newValue as Ptr)
 		  
 		  #if TargetMacOS
 		    declare sub setObject lib Cocoalib selector "setObject:forKey:" ( id as Ptr, key as Ptr, value as Ptr )
 		    
-		    dim truekey as NSObject
-		    
-		    if key IsA NSObject then
-		      truekey = key
-		    else
-		      truekey = Cocoa.NSObjectFromVariant( key )
-		    end if
-		    
-		    setObject( me.id, newValue.id, truekey.id )
+		    setObject(self, newValue, key)
 		  #endif
-		End Sub
-	#tag EndMethod
-
-	#tag Method, Flags = &h1021
-		Private Sub Value_(key as NSObject, assigns anObject as NSObject)
-		  
-		  #if targetMacOS
-		    declare sub setObject lib CocoaLib selector "setObject:forKey:" (obj_id as Ptr, anObject as Ptr, key as Ptr)
-		    
-		    dim objRef as Ptr
-		    if anObject <> nil then
-		      objRef = anObject
-		    end if
-		    
-		    dim keyRef as Ptr
-		    if key <> nil then
-		      keyRef = key
-		    end if
-		    
-		    setObject self, objRef, keyRef
-		    
-		  #else
-		    #pragma unused key
-		    #pragma unused anObject
-		  #endif
-		  
-		End Sub
-	#tag EndMethod
-
-	#tag Method, Flags = &h1021
-		Private Sub Value_(key as String, assigns anObject as NSObject)
-		  
-		  #if targetMacOS
-		    declare sub setValue lib CocoaLib selector "setValue:forKey:" (obj_id as Ptr, anObject as Ptr, key as CFStringRef)
-		    
-		    dim objRef as Ptr
-		    if anObject <> nil then
-		      objRef = anObject
-		    end if
-		    
-		    setValue self, objRef, key
-		    
-		  #else
-		    #pragma unused key
-		    #pragma unused anObject
-		  #endif
-		  
 		End Sub
 	#tag EndMethod
 

--- a/macoslib/Cocoa/NSWorkspace.rbbas
+++ b/macoslib/Cocoa/NSWorkspace.rbbas
@@ -267,161 +267,161 @@ Inherits NSObject
 		    dim userinfo as NSDictionary
 		    dim appl as Cocoa.NSRunningApplication
 		    dim locName as string
-		    dim url as CoreFoundation.CFURL
+		    dim url as NSURL
 		    
-		    declare function valueForKey lib CocoaLib selector "valueForKey:" (id as Ptr, key as CFStringRef) as Ptr //Access to NSDictionary for non-CFType values
+		    declare function objectForKey lib CocoaLib selector "objectForKey:" (id as Ptr, key as Ptr) as Ptr
 		    
 		    select case notification.Name
 		    case "NSWorkspaceWillLaunchApplicationNotification"
 		      userinfo = notification.UserInfo
 		      if IsSnowLeopard then
-		        appl = new NSRunningApplication( valueForKey( userinfo, Cocoa.StringConstant( "NSWorkspaceApplicationKey" )), false )
+		        appl = new NSRunningApplication(objectForKey(userinfo, NSWorkspaceApplicationKey))
 		      end if
 		      
-		      RaiseEvent   NSWorkspaceWillLaunchApplicationNotification( notification, appl )
+		      RaiseEvent NSWorkspaceWillLaunchApplicationNotification( notification, appl )
 		      
 		      
 		    case "NSWorkspaceDidLaunchApplicationNotification"
 		      userinfo = notification.UserInfo
 		      if IsSnowLeopard then
-		        appl = new NSRunningApplication( valueForKey( userinfo, Cocoa.StringConstant( "NSWorkspaceApplicationKey" )), false )
+		        appl = new NSRunningApplication(objectForKey(userinfo, NSWorkspaceApplicationKey))
 		      end if
 		      
-		      RaiseEvent   NSWorkspaceDidLaunchApplicationNotification( notification, appl )
+		      RaiseEvent NSWorkspaceDidLaunchApplicationNotification( notification, appl )
 		      
 		      
 		    case "NSWorkspaceDidTerminateApplicationNotification"
 		      userinfo = notification.UserInfo
 		      if IsSnowLeopard then
-		        appl = new NSRunningApplication( valueForKey( userinfo, Cocoa.StringConstant( "NSWorkspaceApplicationKey" )), false )
+		        appl = new NSRunningApplication(objectForKey(userinfo, NSWorkspaceApplicationKey))
 		      end if
 		      
-		      RaiseEvent   NSWorkspaceDidTerminateApplicationNotification( notification, appl )
+		      RaiseEvent NSWorkspaceDidTerminateApplicationNotification( notification, appl )
 		      
 		      
 		    case "NSWorkspaceSessionDidBecomeActiveNotification"
-		      RaiseEvent   NSWorkspaceSessionDidBecomeActiveNotification( notification )
+		      RaiseEvent NSWorkspaceSessionDidBecomeActiveNotification( notification )
 		      
 		      
 		    case "NSWorkspaceSessionDidResignActiveNotification"
-		      RaiseEvent   NSWorkspaceSessionDidResignActiveNotification( notification )
+		      RaiseEvent NSWorkspaceSessionDidResignActiveNotification( notification )
 		      
 		      
 		    case "NSWorkspaceDidHideApplicationNotification"
 		      userinfo = notification.UserInfo
 		      if IsSnowLeopard then
-		        appl = new NSRunningApplication( valueForKey( userinfo, Cocoa.StringConstant( "NSWorkspaceApplicationKey" )), false )
+		        appl = new NSRunningApplication(objectForKey(userinfo, NSWorkspaceApplicationKey))
 		      end if
 		      
-		      RaiseEvent   NSWorkspaceDidHideApplicationNotification( notification, appl )
+		      RaiseEvent NSWorkspaceDidHideApplicationNotification( notification, appl )
 		      
 		      
 		    case "NSWorkspaceDidUnhideApplicationNotification"
 		      userinfo = notification.UserInfo
 		      if IsSnowLeopard then
-		        appl = new NSRunningApplication( valueForKey( userinfo, Cocoa.StringConstant( "NSWorkspaceApplicationKey" )), false )
+		        appl = new NSRunningApplication(objectForKey(userinfo, NSWorkspaceApplicationKey))
 		      end if
 		      
-		      RaiseEvent   NSWorkspaceDidUnhideApplicationNotification( notification, appl )
+		      RaiseEvent NSWorkspaceDidUnhideApplicationNotification( notification, appl )
 		      
 		      
 		    case "NSWorkspaceDidActivateApplicationNotification"
 		      userinfo = notification.UserInfo
 		      if IsSnowLeopard then
-		        appl = new NSRunningApplication( valueForKey( userinfo, Cocoa.StringConstant( "NSWorkspaceApplicationKey" )), false )
+		        appl = new NSRunningApplication(objectForKey(userinfo, NSWorkspaceApplicationKey))
 		      end if
 		      
-		      RaiseEvent   NSWorkspaceDidActivateApplicationNotification( notification, appl )
+		      RaiseEvent NSWorkspaceDidActivateApplicationNotification( notification, appl )
 		      
 		      
 		    case "NSWorkspaceDidDeactivateApplicationNotification"
 		      userinfo = notification.UserInfo
 		      if IsSnowLeopard then
-		        appl = new NSRunningApplication( valueForKey( userinfo, Cocoa.StringConstant( "NSWorkspaceApplicationKey" )), false )
+		        appl = new NSRunningApplication(objectForKey(userinfo, NSWorkspaceApplicationKey))
 		      end if
 		      
-		      RaiseEvent   NSWorkspaceDidDeactivateApplicationNotification( notification, appl )
+		      RaiseEvent NSWorkspaceDidDeactivateApplicationNotification( notification, appl )
 		      
 		      
 		    case "NSWorkspaceDidRenameVolumeNotification"
 		      userinfo = notification.UserInfo
 		      dim oldLocName as string
-		      dim oldurl as CoreFoundation.CFURL
+		      dim oldurl as NSURL
 		      
 		      if IsSnowLeopard then
-		        locName = userinfo.Value( CFString( Cocoa.StringConstant( "NSWorkspaceVolumeLocalizedNameKey" )))'.VariantValue
-		        url = CoreFoundation.CFURL( userinfo.Value( CFString( Cocoa.StringConstant( "NSWorkspaceVolumeURLKey" ))))
-		        oldLocName = userinfo.Value( CFString( Cocoa.StringConstant( "NSWorkspaceVolumeOldLocalizedNameKey" )))'.VariantValue
-		        oldurl = CoreFoundation.CFURL( userinfo.Value( CFString( Cocoa.StringConstant( "NSWorkspaceVolumeOldURLKey" ))))
+		        locName = new NSString(objectForKey(userinfo, NSWorkspaceVolumeLocalizedNameKey))
+		        url = new NSURL(objectForKey(userinfo, NSWorkspaceVolumeURLKey))
+		        oldLocName = new NSString(objectForKey(userinfo, NSWorkspaceVolumeOldLocalizedNameKey))
+		        oldurl = new NSURL(objectForKey(userinfo, NSWorkspaceVolumeOldURLKey))
 		      end if
 		      
-		      RaiseEvent  NSWorkspaceDidRenameVolumeNotification( notification, oldurl, oldLocName, url, locName )
+		      RaiseEvent NSWorkspaceDidRenameVolumeNotification( notification, oldurl, oldLocName, url, locName )
 		      
 		      
 		    case "NSWorkspaceDidMountNotification"
 		      userinfo = notification.UserInfo
 		      
 		      if IsSnowLeopard then
-		        locName = userinfo.Value( CFString( Cocoa.StringConstant( "NSWorkspaceVolumeLocalizedNameKey" )))'.VariantValue
-		        url = CoreFoundation.CFURL( userinfo.Value( CFString( Cocoa.StringConstant( "NSWorkspaceVolumeURLKey" ))))
+		        locName = new NSString(objectForKey(userinfo, NSWorkspaceVolumeLocalizedNameKey))
+		        url = new NSURL(objectForKey(userinfo, NSWorkspaceVolumeURLKey))
 		      end if
 		      
-		      RaiseEvent  NSWorkspaceDidMountNotification( notification, url, locName )
+		      RaiseEvent NSWorkspaceDidMountNotification( notification, url, locName )
 		      
 		      
 		    case "NSWorkspaceWillUnmountNotification"
 		      userinfo = notification.UserInfo
 		      
 		      if IsSnowLeopard then
-		        locName = userinfo.Value( CFString( Cocoa.StringConstant( "NSWorkspaceVolumeLocalizedNameKey" )))'.VariantValue
-		        url = CoreFoundation.CFURL( userinfo.Value( CFString( Cocoa.StringConstant( "NSWorkspaceVolumeURLKey" ))))
+		        locName = new NSString(objectForKey(userinfo, NSWorkspaceVolumeLocalizedNameKey))
+		        url = new NSURL(objectForKey(userinfo, NSWorkspaceVolumeURLKey))
 		      end if
 		      
-		      RaiseEvent  NSWorkspaceWillUnmountNotification( notification, url, locName )
+		      RaiseEvent NSWorkspaceWillUnmountNotification(notification, url, locName)
 		      
 		      
 		    case "NSWorkspaceDidUnmountNotification"
 		      userinfo = notification.UserInfo
 		      
 		      if IsSnowLeopard then
-		        locName = userinfo.Value( CFString( Cocoa.StringConstant( "NSWorkspaceVolumeLocalizedNameKey" )))'.VariantValue
-		        url = CoreFoundation.CFURL( userinfo.Value( CFString( Cocoa.StringConstant( "NSWorkspaceVolumeURLKey" ))))
+		        locName = new NSString(objectForKey(userinfo, NSWorkspaceVolumeLocalizedNameKey))
+		        url = new NSURL(objectForKey(userinfo, NSWorkspaceVolumeURLKey))
 		      end if
 		      
-		      RaiseEvent  NSWorkspaceDidUnmountNotification( notification, url, locName )
+		      RaiseEvent NSWorkspaceDidUnmountNotification( notification, url, locName )
 		      
 		      
 		    case "NSWorkspaceDidPerformFileOperationNotification"
 		      dim opNbr as Cocoa.NSNumber
 		      userinfo = notification.UserInfo
-		      opNbr = new NSNumber( valueForKey( userinfo, CFString( "NSOperationNumber" )), false )
+		      opNbr = new NSNumber(objectForKey(userinfo, new NSString("NSOperationNumber")))
 		      
-		      RaiseEvent   NSWorkspaceDidPerformFileOperationNotification( notification, opNbr.Int32Value )
+		      RaiseEvent  NSWorkspaceDidPerformFileOperationNotification( notification, opNbr.Int32Value )
 		      
 		      
 		    case "NSWorkspaceDidChangeFileLabelsNotification"
-		      RaiseEvent   NSWorkspaceDidChangeFileLabelsNotification( notification )
+		      RaiseEvent  NSWorkspaceDidChangeFileLabelsNotification( notification )
 		      
 		    case "NSWorkspaceActiveSpaceDidChangeNotification"
-		      RaiseEvent   NSWorkspaceActiveSpaceDidChangeNotification( notification )
+		      RaiseEvent  NSWorkspaceActiveSpaceDidChangeNotification( notification )
 		      
 		    case "NSWorkspaceDidWakeNotification"
-		      RaiseEvent   NSWorkspaceDidWakeNotification( notification )
+		      RaiseEvent  NSWorkspaceDidWakeNotification( notification )
 		      
 		    case "NSWorkspaceWillPowerOffNotification"
-		      RaiseEvent   NSWorkspaceWillPowerOffNotification( notification )
+		      RaiseEvent  NSWorkspaceWillPowerOffNotification( notification )
 		      
 		    case "NSWorkspaceWillSleepNotification"
-		      RaiseEvent   NSWorkspaceWillSleepNotification( notification )
+		      RaiseEvent  NSWorkspaceWillSleepNotification( notification )
 		      
 		    case "NSWorkspaceScreensDidSleepNotification"
-		      RaiseEvent   NSWorkspaceScreensDidSleepNotification( notification )
+		      RaiseEvent  NSWorkspaceScreensDidSleepNotification( notification )
 		      
 		    case "NSWorkspaceScreensDidWakeNotification"
-		      RaiseEvent   NSWorkspaceScreensDidWakeNotification( notification )
+		      RaiseEvent  NSWorkspaceScreensDidWakeNotification( notification )
 		      
 		    else
-		      RaiseEvent   NSWorkspaceOtherNotification( notification )
+		      RaiseEvent  NSWorkspaceOtherNotification( notification )
 		    end select
 		  #endif
 		End Sub
@@ -662,26 +662,31 @@ Inherits NSObject
 		End Function
 	#tag EndMethod
 
+	#tag Method, Flags = &h21
+		Private Shared Function NSStringConstant(symbolName as String) As NSString
+		  dim b as CFBundle = CFBundle.NewCFBundleFromID("com.apple.Cocoa")
+		  return new NSString(b.DataPointerNotRetained(symbolName))
+		End Function
+	#tag EndMethod
+
 	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceApplicationKey() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceApplicationKey")
+		 Shared Function NSWorkspaceApplicationKey() As NSString
+		  return NSStringConstant("NSWorkspaceApplicationKey")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceCompressOperation() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceCompressOperation")
+		 Shared Function NSWorkspaceCompressOperation() As NSString
+		  return NSStringConstant("NSWorkspaceCompressOperation")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceCopyOperation() As String
+		 Shared Function NSWorkspaceCopyOperation() As NSString
 		  
-		  return Cocoa.StringConstant("NSWorkspaceCopyOperation")
+		  return NSStringConstant("NSWorkspaceCopyOperation")
 		  
 		End Function
 	#tag EndMethod
@@ -689,151 +694,134 @@ Inherits NSObject
 	#tag Method, Flags = &h0
 		 Shared Function NSWorkspaceDecompressOperation() As String
 		  
-		  return Cocoa.StringConstant("NSWorkspaceDecompressOperation")
+		  return NSStringConstant("NSWorkspaceDecompressOperation")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceDecryptOperation() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceDecryptOperation")
-		  
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceDesktopImageAllowClippingKey() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceDesktopImageAllowClippingKey")
+		 Shared Function NSWorkspaceDecryptOperation() As NSString
+		  return NSStringConstant("NSWorkspaceDecryptOperation")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceDesktopImageFillColorKey() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceDesktopImageFillColorKey")
-		  
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceDesktopImageScalingKey() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceDesktopImageScalingKey")
+		 Shared Function NSWorkspaceDesktopImageAllowClippingKey() As NSString
+		  return NSStringConstant("NSWorkspaceDesktopImageAllowClippingKey")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceDestroyOperation() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceDestroyOperation")
-		  
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceDuplicateOperation() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceDuplicateOperation")
+		 Shared Function NSWorkspaceDesktopImageFillColorKey() As NSString
+		  return NSStringConstant("NSWorkspaceDesktopImageFillColorKey")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceEncryptOperation() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceEncryptOperation")
-		  
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceLaunchConfigurationAppleEvent() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceLaunchConfigurationAppleEvent")
+		 Shared Function NSWorkspaceDesktopImageScalingKey() As NSString
+		  return NSStringConstant("NSWorkspaceDesktopImageScalingKey")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceLaunchConfigurationArchitecture() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceLaunchConfigurationArchitecture")
-		  
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceLaunchConfigurationArguments() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceLaunchConfigurationArguments")
+		 Shared Function NSWorkspaceDestroyOperation() As NSString
+		  return NSStringConstant("NSWorkspaceDestroyOperation")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceLaunchConfigurationEnvironment() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceLaunchConfigurationEnvironment")
-		  
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceLinkOperation() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceLinkOperation")
+		 Shared Function NSWorkspaceDuplicateOperation() As NSString
+		  return NSStringConstant("NSWorkspaceDuplicateOperation")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceMoveOperation() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceMoveOperation")
-		  
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceRecycleOperation() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceRecycleOperation")
+		 Shared Function NSWorkspaceEncryptOperation() As NSString
+		  return NSStringConstant("NSWorkspaceEncryptOperation")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceVolumeLocalizedNameKey() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceVolumeLocalizedNameKey")
-		  
-		End Function
-	#tag EndMethod
-
-	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceVolumeOldLocalizedNameKey() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceVolumeOldLocalizedNameKey")
+		 Shared Function NSWorkspaceLaunchConfigurationAppleEvent() As NSString
+		  return NSStringConstant("NSWorkspaceLaunchConfigurationAppleEvent")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceVolumeOldURLKey() As String
-		  
-		  return Cocoa.StringConstant("NSWorkspaceVolumeOldURLKey")
+		 Shared Function NSWorkspaceLaunchConfigurationArchitecture() As NSString
+		  return NSStringConstant("NSWorkspaceLaunchConfigurationArchitecture")
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function NSWorkspaceVolumeURLKey() As String
+		 Shared Function NSWorkspaceLaunchConfigurationArguments() As NSString
+		  return NSStringConstant("NSWorkspaceLaunchConfigurationArguments")
 		  
-		  return Cocoa.StringConstant("NSWorkspaceVolumeURLKey")
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		 Shared Function NSWorkspaceLaunchConfigurationEnvironment() As NSString
+		  return NSStringConstant("NSWorkspaceLaunchConfigurationEnvironment")
+		  
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		 Shared Function NSWorkspaceLinkOperation() As NSString
+		  return NSStringConstant("NSWorkspaceLinkOperation")
+		  
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		 Shared Function NSWorkspaceMoveOperation() As NSString
+		  return NSStringConstant("NSWorkspaceMoveOperation")
+		  
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		 Shared Function NSWorkspaceRecycleOperation() As NSString
+		  return NSStringConstant("NSWorkspaceRecycleOperation")
+		  
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		 Shared Function NSWorkspaceVolumeLocalizedNameKey() As NSString
+		  return NSStringConstant("NSWorkspaceVolumeLocalizedNameKey")
+		  
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		 Shared Function NSWorkspaceVolumeOldLocalizedNameKey() As NSString
+		  return NSStringConstant("NSWorkspaceVolumeOldLocalizedNameKey")
+		  
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		 Shared Function NSWorkspaceVolumeOldURLKey() As NSString
+		  return NSStringConstant("NSWorkspaceVolumeOldURLKey")
+		  
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		 Shared Function NSWorkspaceVolumeURLKey() As NSString
+		  
+		  return NSStringConstant("NSWorkspaceVolumeURLKey")
 		  
 		End Function
 	#tag EndMethod
@@ -1402,7 +1390,7 @@ Inherits NSObject
 	#tag EndHook
 
 	#tag Hook, Flags = &h0
-		Event NSWorkspaceDidMountNotification(notification as NSNotification, url as CoreFoundation.CFURL, localizedName as String)
+		Event NSWorkspaceDidMountNotification(notification as NSNotification, url as NSURL, localizedName as String)
 	#tag EndHook
 
 	#tag Hook, Flags = &h0
@@ -1410,7 +1398,7 @@ Inherits NSObject
 	#tag EndHook
 
 	#tag Hook, Flags = &h0
-		Event NSWorkspaceDidRenameVolumeNotification(notification as NSNotification, oldURL as CoreFoundation.CFURL, oldLocalizedName as string, newURL as CoreFoundation.CFURL, newLocalizedName as string)
+		Event NSWorkspaceDidRenameVolumeNotification(notification as NSNotification, oldURL as NSURL, oldLocalizedName as string, newURL as NSURL, newLocalizedName as string)
 	#tag EndHook
 
 	#tag Hook, Flags = &h0
@@ -1422,7 +1410,7 @@ Inherits NSObject
 	#tag EndHook
 
 	#tag Hook, Flags = &h0
-		Event NSWorkspaceDidUnmountNotification(notification as NSNotification, url as CoreFoundation.CFURL, localizedName as String)
+		Event NSWorkspaceDidUnmountNotification(notification as NSNotification, url as NSURL, localizedName as String)
 	#tag EndHook
 
 	#tag Hook, Flags = &h0
@@ -1462,7 +1450,7 @@ Inherits NSObject
 	#tag EndHook
 
 	#tag Hook, Flags = &h0
-		Event NSWorkspaceWillUnmountNotification(notification as NSNotification, url as CoreFoundation.CFURL, localizedName as String)
+		Event NSWorkspaceWillUnmountNotification(notification as NSNotification, url as NSURL, localizedName as String)
 	#tag EndHook
 
 

--- a/macoslib/CocoaToolbar/NSToolbar.rbbas
+++ b/macoslib/CocoaToolbar/NSToolbar.rbbas
@@ -444,7 +444,7 @@ Inherits NSObject
 		  dim item as NSToolbarItem
 		  
 		  if d <> nil then
-		    itemPtr = d.Lookup("item", nil) // get the Ptr to the NSToolbarItem
+		    itemPtr = d.Value(new NSString("item")) // get the Ptr to the NSToolbarItem
 		    
 		    if itemPtr <> nil then
 		      dim tmpItem as NSToolbarItem = new NSToolbarItem(itemPtr) // construct a NSToolbarItem from Ptr
@@ -511,16 +511,14 @@ Inherits NSObject
 		  
 		  // get the notification info dictionary which contains "item" key
 		  dim d as NSDictionary = notification.UserInfo
-		  dim itemPtr as Ptr
-		  dim item as NSToolbarItem
 		  
 		  if d <> nil then
-		    itemPtr = d.Lookup("item", nil) // get the Ptr to the NSToolbarItem
+		    dim itemPtr as Ptr = d.Value(new NSString("item")) // get the Ptr to the NSToolbarItem
 		    
 		    if itemPtr <> nil then
 		      dim tmpItem as NSToolbarItem = new NSToolbarItem(itemPtr) // construct a NSToolbarItem from Ptr
 		      dim tmpIdentifier as String = tmpItem.itemIdentifier // get the item identifier
-		      item = ToolbarItems.Lookup(tmpIdentifier, nil) // lookup the item in local dictionary
+		      dim item as NSToolbarItem = ToolbarItems.Lookup(tmpIdentifier, nil) // lookup the item in local dictionary
 		      if item = nil then // items are normally present but that's not true for standard items (space, separator, color, print, etc.)
 		        item = tmpItem
 		        ToolbarItems.value(tmpIdentifier) = item // so we eventually add them to the local dictionary

--- a/macoslib/ImageKit & ImageCapture/ICCameraDevice.rbbas
+++ b/macoslib/ImageKit & ImageCapture/ICCameraDevice.rbbas
@@ -583,11 +583,11 @@ Inherits ICDevice
 		    
 		    dim dict as new NSMutableDictionary
 		    if options<>nil then
-		      dict.AppendDictionary   options
+		      dict.AddEntries options
 		    end if
-		    dict.Value( "ICDownloadsDirectoryURL" ) = new NSURL( targetFolder )
+		    dict.Value(new NSString("ICDownloadsDirectoryURL")) = new NSURL( targetFolder )
 		    
-		    requestDownloadFile( me.id, file.id, dict.id, me.GetDelegate, Cocoa.NSSelectorFromString( "didDownloadFile:error:options:contextInfo:" ), nil )
+		    requestDownloadFile(self, file, dict, self.GetDelegate, Cocoa.NSSelectorFromString( "didDownloadFile:error:options:contextInfo:" ), nil )
 		    
 		  #endif
 		End Sub


### PR DESCRIPTION
NSDIctionary and NSMutableDictionary Value methods all take a Ptr argument, and return a Ptr.  My experience with other code suggests that this is the right interface for now.  All other approaches involve endless typecasting or the use of lookup table that requires maintenance.  In most cases, one knows the type of the value returned for a given key, and thus one can simply pass the Ptr returned for a key to the correct constructor.
