### PR TITLE
Friggen github!

### DIFF
--- a/macoslib/Cocoa/NSWorkspace.rbbas
+++ b/macoslib/Cocoa/NSWorkspace.rbbas
@@ -1102,8 +1102,8 @@ Inherits NSObject
 		    declare sub reveal lib CocoaLib selector "activateFileViewerSelectingURLs:" (id as Ptr, urls as Ptr)
 		    declare function respondsToSelector lib "Cocoa" selector "respondsToSelector:" (obj as Ptr, sel as Ptr) as Boolean
 		    
-		    dim id as Ptr = NSWorkspace.sharedInstance
-		    if id <> nil then
+		    if files.Ubound >= 0 then
+		      dim id as Ptr = SharedWorkspace
 		      if respondsToSelector (id, Cocoa.NSSelectorFromString("activateFileViewerSelectingURLs:")) then
 		        dim arr as new CFMutableArray
 		        for each f as FolderItem in files
@@ -1113,19 +1113,26 @@ Inherits NSObject
 		        return true
 		      end if
 		    end if
+		    
+		  #else
+		    #pragma unused files
 		  #endif
+		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
 		 Shared Sub RevealFileURLs(fileURLs() as NSURL)
-		  
 		  #if targetMacOS
 		    declare sub activateFileViewerSelectingURLs lib CocoaLib selector "activateFileViewerSelectingURLs:" (obj_id as Ptr, fileURLs as Ptr)
+		    declare function respondsToSelector lib "Cocoa" selector "respondsToSelector:" (obj as Ptr, sel as Ptr) as Boolean
 		    
 		    if fileURLs.ubound >= 0 then
-		      dim URLsArray as NSArray = NSArray.CreateWithObjects(fileURLs)
-		      activateFileViewerSelectingURLs(SharedWorkspace, URLsArray)
+		      dim id as Ptr = SharedWorkspace
+		      if respondsToSelector (id, Cocoa.NSSelectorFromString("activateFileViewerSelectingURLs:")) then
+		        dim URLsArray as NSArray = NSArray.CreateWithObjects(fileURLs)
+		        activateFileViewerSelectingURLs(id, URLsArray)
+		      end if
 		    end if
 		    
 		  #else
@@ -1133,7 +1140,6 @@ Inherits NSObject
 		  #endif
 		  
 		End Sub
->>>>>>> refs/remotes/root/master
 	#tag EndMethod
 
 	#tag Method, Flags = &h0


### PR DESCRIPTION
- NSWorkspace.RevealFileURLs checks of function availability before invoking it to avoid crash on pre-10.6 systems.
- Adds NSWorkspace.RevealFiles(f() as FolderItem) because we also have a SelectFile that takes a FolderItem.
