### PR TITLE
Fix a bug in LaunchServices.SendURLToApplication; the FSRef created for ...

### DIFF
--- a/About.rbbas
+++ b/About.rbbas
@@ -70,6 +70,9 @@ Protected Module About
 		Add new notes above existing ones, and remember to increment the Version constant.
 		Contributors are identified by initials. See the "Contributors" note for full names.
 		
+		152: 2013-10-16 by CY
+		-Fix a bug in LaunchServices.SendURLToApplication.
+		
 		151: 2013-09-28 by SM
 		- Implemented most of the ImageKit IKImageBrowserView with all the necessary IK classes: IKImageBrowserCell, IKImageBrowserItem, IKImageBrowserDataSource.
 		- Set SizeOfInteger as a global method in Cocoa
@@ -383,7 +386,7 @@ Protected Module About
 	#tag EndNote
 
 
-	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"151", Scope = Protected
+	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"152", Scope = Protected
 	#tag EndConstant
 
 

--- a/macoslib/LaunchServices.rbbas
+++ b/macoslib/LaunchServices.rbbas
@@ -256,7 +256,6 @@ Protected Module LaunchServices
 
 	#tag Method, Flags = &h0
 		Sub SendURLToApplication(url as String, appItem as FolderItem)
-		  
 		  if url = "" then
 		    return
 		  end if
@@ -267,15 +266,15 @@ Protected Module LaunchServices
 		  #if targetMacOS
 		    soft declare function LSOpenURLsWithRole lib CarbonLib (inURLs as Ptr, inRole as UInt32, inAEParam as Ptr, ByRef inAppParams as LSApplicationParameters, outPSNs as Ptr, inMaxPSNCount as Integer) as Integer
 		    
-		    
 		    dim theArray as new CFArray(Array(new CFURL(url)))
 		    const paramIgnoredBecauseinAppParamsNotNil = 0
 		    
 		    dim appParams as LSApplicationParameters
-		    appParams.application = FileManager.GetFSRefFromFolderItem(appItem)
+		    //we need to keep a reference to the MemoryBlock so that the object lives through the call to LSOpenURLsWithRole.
+		    dim appRef as MemoryBlock = appItem.MacFSRef
+		    appParams.application = appRef
 		    
 		    dim OSError as Integer = LSOpenURLsWithRole(theArray, paramIgnoredBecauseinAppParamsNotNil, nil, appParams, nil, 0)
-		    return
 		    
 		    // Keep the compiler from complaining
 		    #pragma unused OSError


### PR DESCRIPTION
...the application file is no longer destroyed too soon. Increment version to 152.
