### PR TITLE
Various

### DIFF
--- a/About.rbbas
+++ b/About.rbbas
@@ -70,6 +70,14 @@ Protected Module About
 		Add new notes above existing ones, and remember to increment the Version constant.
 		Contributors are identified by initials. See the "Contributors" note for full names.
 		
+		157: 2013-10-31 by KT
+		- Added pragmas for unused method parameters.
+		- Changed NSDictionary to accept and return NativeSubclass.DictionaryCaseSensitive instead of the native Dictionary.
+		- In NSDictionary/CFDictionary, swapped VariantValue and Operator_Convert code to avoid unnecessary conversion to Variant.
+		- Added #if TargetMacOS to CFDictionary.Operator_Convert.
+		- Added optimization to NSDictionary.Operator_Convert.
+		- Verified ability to compile for Windows, Cocoa, and Carbon in Real Studio 2012.
+		 
 		156: 2013-10-26 by KT
 		- Changed name of convenience classes from NSRegEx to MacRegEx.
 		- Added MacSystemProfiler.CurrentSSID shared method as convenience.
@@ -420,7 +428,7 @@ Protected Module About
 	#tag EndNote
 
 
-	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"156", Scope = Protected
+	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"157", Scope = Protected
 	#tag EndConstant
 
 

--- a/macoslib/Cocoa/NSDictionary.rbbas
+++ b/macoslib/Cocoa/NSDictionary.rbbas
@@ -176,7 +176,13 @@ Inherits NSObject
 		    next
 		    
 		    return   md.Copy
+		    
+		  #else
+		    
+		    #pragma unused dict
+		    
 		  #endif
+		  
 		End Function
 	#tag EndMethod
 
@@ -573,9 +579,28 @@ Inherits NSObject
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Function Operator_Convert() As Dictionary
+		Function Operator_Convert() As NativeSubclass.DictionaryCaseSensitive
+		  // Convert to a NativeSubclass.DictionaryCaseSensitive.
+		  // This is a Dictionary subclass that can be assigned to a variable defined
+		  // as a Dictionary. Preserves the case-sensitivity of the NSDictionary.
 		  
-		  return self.VariantValue
+		  #if TargetMacOS
+		    dim dict as new NativeSubclass.DictionaryCaseSensitive
+		    
+		    dim keys as NSArray = me.AllKeys
+		    dim values as NSArray = me.AllValues
+		    dim oneKey, oneValue as objHasVariantValue
+		    
+		    dim lastIndex as integer = keys.Count - 1 // Optimization
+		    for i as integer = 0 to lastIndex
+		      oneKey = Cocoa.NSObjectFromNSPtr( keys.Value( i ))
+		      oneValue = Cocoa.NSObjectFromNSPtr( values.Value( i ))
+		      
+		      dict.Value( oneKey.VariantValue ) = oneValue.VariantValue
+		    next
+		    
+		    return  dict
+		  #endif
 		  
 		End Function
 	#tag EndMethod
@@ -617,25 +642,12 @@ Inherits NSObject
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Function VariantValue() As variant
-		  // Create a RS Dictionary
+		Function VariantValue() As Variant
+		  // Uses Operator_Convert
 		  
-		  #if TargetMacOS
-		    dim dict as new Dictionary
-		    
-		    dim keys as NSArray = me.AllKeys
-		    dim values as NSArray = me.AllValues
-		    dim oneKey, oneValue as objHasVariantValue
-		    
-		    for i as integer = 0 to keys.Count - 1
-		      oneKey = Cocoa.NSObjectFromNSPtr( keys.Value( i ))
-		      oneValue = Cocoa.NSObjectFromNSPtr( values.Value( i ))
-		      
-		      dict.Value( oneKey.VariantValue ) = oneValue.VariantValue
-		    next
-		    
-		    return  dict
-		  #endif
+		  dim r as NativeSubclass.DictionaryCaseSensitive = me.Operator_Convert
+		  return r
+		  
 		End Function
 	#tag EndMethod
 

--- a/macoslib/CoreFoundation/CFDictionary.rbbas
+++ b/macoslib/CoreFoundation/CFDictionary.rbbas
@@ -10,20 +10,10 @@ Implements CFPropertyList
 
 	#tag Event
 		Function VariantValue() As Variant
-		  // Convert to a NativeSubclass.DictionaryCaseSensitive.
-		  // This is a Dictionary subclass that can be assigned to a variable defined
-		  // as a Dictionary.
+		  // Uses Operator_Convert
 		  
-		  dim outDict as new NativeSubclass.DictionaryCaseSensitive
-		  
-		  dim k() as CFType = me.Keys
-		  dim key as CFType
-		  for i as integer = 0 to k.Ubound // Switched from For Each to ensure that order is preserved
-		    key = k( i )
-		    outDict.Value(key.VariantValue) = me.Value(key).VariantValue
-		  next
-		  
-		  return outDict
+		  dim r as NativeSubclass.DictionaryCaseSensitive = me.Operator_Convert
+		  return r
 		  
 		End Function
 	#tag EndEvent
@@ -240,17 +230,24 @@ Implements CFPropertyList
 
 	#tag Method, Flags = &h0
 		Function Operator_Convert() As NativeSubclass.DictionaryCaseSensitive
-		  // Added by Kem Tekinay.
-		  
-		  dim d as NativeSubclass.DictionaryCaseSensitive
+		  // Convert to a NativeSubclass.DictionaryCaseSensitive.
+		  // This is a Dictionary subclass that can be assigned to a variable defined
+		  // as a Dictionary. Preserves the case-sensitivity of the CFDictionary.
 		  
 		  #if TargetMacOS
 		    
-		    d = me.VariantValue
+		    dim outDict as new NativeSubclass.DictionaryCaseSensitive
+		    
+		    dim k() as CFType = me.Keys
+		    dim key as CFType
+		    for i as integer = 0 to k.Ubound // Switched from For Each to ensure that order is preserved
+		      key = k( i )
+		      outDict.Value(key.VariantValue) = me.Value(key).VariantValue
+		    next
+		    
+		    return outDict
 		    
 		  #endif
-		  
-		  return d
 		  
 		End Function
 	#tag EndMethod

--- a/macoslib/ImageKit & ImageCapture/ICScannerDevice.rbbas
+++ b/macoslib/ImageKit & ImageCapture/ICScannerDevice.rbbas
@@ -346,6 +346,11 @@ Inherits ICDevice
 		    ''methodList.Append  "device:didReceiveCustomNotification:data:" : CType( AddressOf delegate_DeviceDidReceiveCustomNotification, Ptr ) : "v@:@@@"
 		    '
 		    'return Cocoa.MakeDelegateClass (className, superclassName, methodList)
+		    
+		    // REMOVE THESE PRAGMAS AFTER THE METHOD IS COMPLETE
+		    #pragma unused className
+		    #pragma unused superClassName
+		    
 		  #else
 		    #pragma unused className
 		    #pragma unused superClassName


### PR DESCRIPTION
- Added pragmas for unused method parameters.
- Changed NSDictionary to accept and return NativeSubclass.DictionaryCaseSensitive instead of the native Dictionary.
- In NSDictionary/CFDictionary, swapped VariantValue and Operator_Convert code to avoid unnecessary conversion to Variant.
- Added #if TargetMacOS to CFDictionary.Operator_Convert.
- Added optimization to NSDictionary.Operator_Convert.
- Verified ability to compile for Windows, Cocoa, and Carbon in Real Studio 2012.
- Version 157.
