### PR TITLE
NSWIndow.AnimationBehavior no longer raises an ObjCException in MacOS 10...

### DIFF
--- a/About.rbbas
+++ b/About.rbbas
@@ -62,6 +62,9 @@ Protected Module About
 		
 		When you make changes, add new notes above existing ones, and remember to increment the Version constant.
 		
+		166: 2013-12-11 by CY
+		-NSWIndow.AnimationBehavior no longer raises an ObjCException in MacOS 10.6; instead the Set handler is a no-op and the Get handler returns NSWindowAnimationBehaviorDefault.
+		
 		165: 2013-12-04 by CY
 		-Refactor CFArray, CFMutableArray, CFAttributedString, CFBundle to use CFTypeRef.
 		
@@ -458,7 +461,7 @@ Protected Module About
 	#tag EndNote
 
 
-	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"165", Scope = Protected
+	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"166", Scope = Protected
 	#tag EndConstant
 
 

--- a/macoslib/Cocoa/NSWindow.rbbas
+++ b/macoslib/Cocoa/NSWindow.rbbas
@@ -1888,10 +1888,15 @@ Inherits NSResponder
 			Get
 			  
 			  #if TargetCocoa
-			    declare function animationBehavior lib CocoaLib selector "animationBehavior" (obj_id as Ptr) as NSWindowAnimationBehavior
+			    //animationBehavior was added in MacOS 10.7.
 			    
-			    return animationBehavior(self)
-			    
+			    static msgAccepted as Boolean = self.respondsToSelector("animationBehavior")
+			    if msgAccepted then
+			      declare function animationBehavior lib CocoaLib selector "animationBehavior" (obj_id as Ptr) as NSWindowAnimationBehavior
+			      return animationBehavior(self)
+			    else
+			      return NSWindowAnimationBehavior.NSWindowAnimationBehaviorDefault
+			    end if
 			  #endif
 			  
 			End Get
@@ -1900,9 +1905,15 @@ Inherits NSResponder
 			Set
 			  
 			  #if TargetCocoa
-			    declare sub setAnimationBehavior lib CocoaLib selector "setAnimationBehavior:" (obj_id as Ptr, behavior as NSWindowAnimationBehavior)
+			    //setAnimationBehavior: was added in Mac OS 10.7.
 			    
-			    setAnimationBehavior self, value
+			    static msgAccepted as Boolean = self.respondsToSelector("setAnimationBehavior:")
+			    if msgAccepted then
+			      declare sub setAnimationBehavior lib CocoaLib selector "setAnimationBehavior:" (obj_id as Ptr, behavior as NSWindowAnimationBehavior)
+			      setAnimationBehavior(self, value)
+			    else
+			      //no-op
+			    end if
 			    
 			  #else
 			    #pragma unused value


### PR DESCRIPTION
....6; instead the Set handler is a no-op and the Get handler returns NSWindowAnimationBehaviorDefault (fixes issue 120).
