### PR TITLE
fix wrong selector name in NSRunningApplication.BundleIdentifier

### DIFF
--- a/macoslib/Cocoa/NSRunningApplication.rbbas
+++ b/macoslib/Cocoa/NSRunningApplication.rbbas
@@ -98,9 +98,9 @@ Inherits NSObject
 		#tag Getter
 			Get
 			  #if targetMacOS
-			    declare function CFBundleIdentifier lib CocoaLib selector "CFBundleIdentifier" (obj_id as Ptr) as Ptr
+			    declare function bundleIdentifier lib CocoaLib selector "bundleIdentifier" (obj_id as Ptr) as Ptr
 			    
-			    return RetainedStringValue( CFBundleIdentifier(self) )
+			    return RetainedStringValue( bundleIdentifier(self) )
 			  #endif
 			End Get
 		#tag EndGetter


### PR DESCRIPTION
Selector should be `bundleIdentifier` instead of `CFBundleIdentifier`.

https://developer.apple.com/library/mac/documentation/AppKit/Reference/NSRunningApplication_Class/Reference/Reference.html#//apple_ref/occ/instp/NSRunningApplication/bundleIdentifier
