### PR TITLE
SystemIcons Example now really showing the system icons …

### DIFF
--- a/Examples/SystemIconsExampleWindow.rbfrm
+++ b/Examples/SystemIconsExampleWindow.rbfrm
@@ -919,7 +919,7 @@ Sub Change()
 		  #if RBVersion >= 2012.02
 		    #pragma unused areas
 		  #endif
-		  
+		 
 		End Sub
 	#tag EndEvent
 #tag EndEvents


### PR DESCRIPTION
, not only the fi.rst in kListboxContent

I realized SystemIcons example was only showing QuicklookTemplate, the
first of the icons listed in kListboxContent.
I removed the residing size informations (like :16:12) in a few of the
constant’s lines and added another loop to LB1’ open method, but let
the first one (although it is only run through once) in case there is
some deeper meaning to it.
