### PR TITLE
Prevent NilObjectException when obj is Nil in NSPathComponentCell.

### DIFF
--- a/About.rbbas
+++ b/About.rbbas
@@ -76,6 +76,7 @@ Protected Module About
 		
 		173: 2014-05-11 by VVB
 		- Add NSObjectFromVariant converts variant.TypeLong to new NSNumber.
+		- Prevent NilObjectException when obj is Nil in NSPathComponentCell.
 		
 		172: 2014-03-03 by KT
 		- NSToolbarCustomItem relied on an extension present only in Additional Modules.

--- a/macoslib/Cocoa/NSPathComponentCell.rbbas
+++ b/macoslib/Cocoa/NSPathComponentCell.rbbas
@@ -8,7 +8,7 @@ Class NSPathComponentCell
 
 	#tag Method, Flags = &h0
 		Function Operator_Compare(obj as NSPathComponentCell) As Integer
-		  if obj.id = nil then
+		  if obj = nil or obj.id = nil then
 		    return 1
 		  else
 		    return Integer(me.id) - Integer(obj.id)


### PR DESCRIPTION
Prevent NilObjectException when obj is Nil in NSPathComponentCell.
