### PR TITLE
OS Version related fixes:

### DIFF
--- a/About.rbbas
+++ b/About.rbbas
@@ -62,6 +62,12 @@ Protected Module About
 		
 		When you make changes, add new notes above existing ones, and remember to increment the Version constant.
 		
+		177: 2014-12-28 by TT
+		- Fixes the Carbon.IsYosemite() and related functions by using the AppKit version number instead of Gestalt().
+		- Fixes the Carbon.SystemVersionAsString() function by using NSProcessInfo.OperatingSystemVersionString instead of Gestalt().
+		- Adds Cocoa.NSAppKitVersionNumber
+		- Improves NSWorkspace.OpenFile to allow using the deafault app when specifying the optional "deactivate" parameter.
+		
 		176: 2014-06-28 by VVB
 		- Added missing 'blueComponent' to NSColor.
 		- Changed NSWindow.Transparency method to use the window's actual background color rather than an aproximation.
@@ -529,7 +535,7 @@ Protected Module About
 	#tag EndNote
 
 
-	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"176", Scope = Protected
+	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"177", Scope = Protected
 	#tag EndConstant
 
 

--- a/Application/App.rbbas
+++ b/Application/App.rbbas
@@ -668,26 +668,9 @@ Inherits Application
 
 	#tag Method, Flags = &h1
 		Protected Sub TestCarbon()
-		  select case Carbon.GetSystemVersionFromGestalt.Left(4)
-		  case "10.3"
-		    pTestAssert IsPanther
-		    pTestAssert not IsTiger
-		  case "10.4"
-		    pTestAssert IsPanther
-		    pTestAssert IsTiger
-		    pTestAssert not IsLeopard
-		  case "10.5"
-		    pTestAssert IsTiger
-		    pTestAssert IsLeopard
-		    pTestAssert not IsSnowLeopard
-		  case "10.6"
-		    pTestAssert IsLeopard
-		    pTestAssert IsSnowLeopard
-		    pTestAssert not IsLion
-		  else
-		    pTestAssert IsSnowLeopard
-		    pTestAssert IsLion
-		  end select
+		  dim osversion as Integer = Carbon.SystemVersionAsInt
+		  dim nsversion as Double = Cocoa.NSAppKitVersionNumber
+		  dim cfversion as Double = CoreFoundation.Version
 		  
 		End Sub
 	#tag EndMethod

--- a/macoslib/Cocoa/Cocoa.rbbas
+++ b/macoslib/Cocoa/Cocoa.rbbas
@@ -300,6 +300,19 @@ Protected Module Cocoa
 		End Function
 	#tag EndMethod
 
+	#tag Method, Flags = &h1
+		Protected Function NSAppKitVersionNumber() As Double
+		  #if TargetMacOS
+		    static d as Double
+		    if d = 0 then
+		      dim mb as MemoryBlock = CFBundle.NewCFBundleFromID("com.apple.Cocoa").DataPointerNotRetained("NSAppKitVersionNumber")
+		      d = mb.DoubleValue(0)
+		    end if
+		    return d
+		  #endif
+		End Function
+	#tag EndMethod
+
 	#tag ExternalMethod, Flags = &h1
 		Protected Declare Function NSClassFromString Lib CocoaLib (aClassName as CFStringRef) As Ptr
 	#tag EndExternalMethod

--- a/macoslib/Cocoa/NSProcessInfo.rbbas
+++ b/macoslib/Cocoa/NSProcessInfo.rbbas
@@ -229,6 +229,33 @@ Inherits NSObject
 	#tag ComputedProperty, Flags = &h0
 		#tag Getter
 			Get
+			  // Available in OS X v10.10 and later.
+			  //
+			  // Returns 0, 0, 0 if called on systems before 10.10.
+			  //
+			  // Hint: If you need this to work on pre-10.10 systems, use Carbon.SystemVersionAsInt
+			  
+			  #if TargetMacOS
+			    declare function operatingSystemVersion lib CocoaLib selector "operatingSystemVersion" (obj_id as Ptr) as OSVersion
+			    
+			    if me.RespondsToSelector("operatingSystemVersion") then
+			      'dim mb as Ptr = operatingSystemVersion(self)
+			      dim result as OSVersion = operatingSystemVersion(self)
+			      'result.major = mb.Int32Value(0)
+			      'result.minor = mb.Int32Value(4)
+			      'result.patch = mb.Int32Value(8)
+			      return result
+			    end if
+			  #endif
+			  
+			End Get
+		#tag EndGetter
+		OperatingSystemVersion As OSVersion
+	#tag EndComputedProperty
+
+	#tag ComputedProperty, Flags = &h0
+		#tag Getter
+			Get
 			  
 			  #if targetMacOS
 			    declare function operatingSystemVersionString lib CocoaLib selector "operatingSystemVersionString" (obj_id as Ptr) as CFStringRef
@@ -360,6 +387,13 @@ Inherits NSObject
 
 	#tag Constant, Name = NSWindowsNTOperatingSystem, Type = Double, Dynamic = False, Default = \"1", Scope = Public
 	#tag EndConstant
+
+
+	#tag Structure, Name = OSVersion, Flags = &h0
+		major as Integer
+		  minor as Integer
+		patch as Integer
+	#tag EndStructure
 
 
 	#tag ViewBehavior


### PR DESCRIPTION
- Fixes the Carbon.IsYosemite() and related functions by using the AppKit version number instead of Gestalt().
- Fixes the Carbon.SystemVersionAsString() function by using NSProcessInfo.OperatingSystemVersionString instead of Gestalt().
- Adds Cocoa.NSAppKitVersionNumber
