### PR TITLE
remove setter for NSPopover.Shown as it is readonly

### DIFF
--- a/macoslib/Cocoa/NSPopover.rbbas
+++ b/macoslib/Cocoa/NSPopover.rbbas
@@ -460,18 +460,6 @@ Inherits NSResponder
 			  #endif
 			End Get
 		#tag EndGetter
-		#tag Setter
-			Set
-			  
-			  #if TargetMacOS then
-			    declare sub setShown lib CocoaLib selector "setShown:" (obj_id as Ptr, value as Boolean)
-			    
-			    setShown self, value
-			  #else
-			    #pragma Unused value
-			  #endif
-			End Set
-		#tag EndSetter
 		Shown As Boolean
 	#tag EndComputedProperty
 


### PR DESCRIPTION
NSPopover's property `shown` is readonly.

https://developer.apple.com/library/mac/documentation/AppKit/Reference/NSPopover_Class/#//apple_ref/occ/instp/NSPopover/shown