### PR TITLE
Xojo Date to CFDate timezone conversion fix

### DIFF
--- a/About.rbbas
+++ b/About.rbbas
@@ -30,6 +30,7 @@ Protected Module About
 		Stéphane Mons (SM)
 		Kem Tekinay (KT)
 		Vidal van Bergen (VVB)
+		Jeff Fowler (JF)
 	#tag EndNote
 
 	#tag Note, Name = Documentation
@@ -61,6 +62,9 @@ Protected Module About
 		for previous release notes. Contributors are identified by initials. See the "Contributors" note for full names.
 		
 		When you make changes, add new notes above existing ones, and remember to increment the Version constant.
+		
+		178: 2015-01-12 by JF
+		- Fixes incorrect handling of timezone in CFDate.Constructor(d as Date) and CFDate.Operator_Convert() As Date.
 		
 		177: 2014-12-28 by TT
 		- Fixes the Carbon.IsYosemite() and related functions by using the AppKit version number instead of Gestalt().
@@ -535,7 +539,7 @@ Protected Module About
 	#tag EndNote
 
 
-	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"177", Scope = Protected
+	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"178", Scope = Protected
 	#tag EndConstant
 
 

--- a/macoslib/CoreFoundation/CFDate.rbbas
+++ b/macoslib/CoreFoundation/CFDate.rbbas
@@ -50,6 +50,10 @@ Implements CFPropertyList
 		    d = new Date
 		  end if
 		  
+		  // convert d.TotalSeconds to absolute time
+		  d = new Date(d)
+		  d.GMTOffset = 0.0
+		  
 		  me.Constructor d.TotalSeconds - AbsoluteTimeIntervalSince1904
 		End Sub
 	#tag EndMethod
@@ -161,7 +165,17 @@ Implements CFPropertyList
 		  else
 		    
 		    dim d as new Date
+		    
+		    // save d.GMTOffset
+		    dim gmt As Double = d.GMTOffset
+		    
+		    // d.TotalSeconds depends on d.GMTOffset, convert to absolute time before assignment
+		    d.GMTOffset = 0.0
 		    d.TotalSeconds = me.AbsoluteTime + AbsoluteTimeIntervalSince1904
+		    
+		    // restore original d.GMTOffset
+		    d.GMTOffset = gmt
+		    
 		    return d
 		    
 		  end if


### PR DESCRIPTION
Xojo Date.TotalSeconds is dependent on Date.GMTOffset so conversion to
and from absolute time requires Date.GMTOffset to be 0.