### PR TITLE
Fix Declares that leaks dependency to Cocoa.framework and libobjc.A.dylib on non-Mac platform

### DIFF
--- a/About.rbbas
+++ b/About.rbbas
@@ -31,6 +31,7 @@ Protected Module About
 		Kem Tekinay (KT)
 		Vidal van Bergen (VVB)
 		Jeff Fowler (JF)
+		Kenichi Maehashi (KM)
 	#tag EndNote
 
 	#tag Note, Name = Documentation
@@ -62,6 +63,10 @@ Protected Module About
 		for previous release notes. Contributors are identified by initials. See the "Contributors" note for full names.
 		
 		When you make changes, add new notes above existing ones, and remember to increment the Version constant.
+		
+		183: 2015-02-26 by KM
+		- Changed Cocoa.NSClassFromString from External Method to Shared Method to improve cross-platform compatibility.
+		- Fixed Cocoa.CocoaDelegate and Cocoa.NSArray using Declare without 'ifdef' block.
 		
 		182: 2015-01-23 by VVB
 		- Moved some extension enumerators that were valid for multiple controls to ControlExtension.
@@ -567,7 +572,7 @@ Protected Module About
 	#tag EndNote
 
 
-	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"182", Scope = Protected
+	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"183", Scope = Protected
 	#tag EndConstant
 
 

--- a/macoslib/Cocoa/Cocoa.rbbas
+++ b/macoslib/Cocoa/Cocoa.rbbas
@@ -313,9 +313,14 @@ Protected Module Cocoa
 		End Function
 	#tag EndMethod
 
-	#tag ExternalMethod, Flags = &h1
-		Protected Declare Function NSClassFromString Lib CocoaLib (aClassName as CFStringRef) As Ptr
-	#tag EndExternalMethod
+	#tag Method, Flags = &h1
+		Protected Function NSClassFromString(aClassName as CFStringRef) As Ptr
+		  #if TargetMacOS
+		    Declare Function NSClassFromString Lib CocoaLib (aClassName as CFStringRef) As Ptr
+		    Return NSClassFromString(aClassName)
+		  #endif
+		End Function
+	#tag EndMethod
 
 	#tag ExternalMethod, Flags = &h1
 		Protected Declare Function NSFullUserName Lib CocoaLib () As CFStringRef

--- a/macoslib/Cocoa/CocoaDelegate.rbbas
+++ b/macoslib/Cocoa/CocoaDelegate.rbbas
@@ -17,31 +17,33 @@ Inherits NSObject
 		  // This is an abstract class to construct Cocoa delegates. It must not be directly instantiated, instead it must be subclassed.
 		  // A subclass MUST implement the events to provide a name for the Cocoa class and delegate methods
 		  
-		  mClassName = raiseEvent DelegateClassName // get the Class name and store it
-		  const superClassName = "NSObject"
-		  dim protocols() as String = raiseEvent DelegateProtocols
-		  
-		  declare function alloc lib CocoaLib selector "alloc" (class_id as Ptr) as Ptr
-		  
-		  // allocate the instance
-		  dim delegate_id as Ptr = Initialize(alloc(RegisterClass(ClassName, superClassName, protocols)))
-		  super.Constructor(delegate_id, NSObject.hasOwnership) // construct the super object (NSObject)
-		  
-		  // store the instance in a static map
-		  CocoaDelegateMap.Value(delegate_id) = new WeakRef(self)
-		  
+		  #if TargetMacOS
+		    mClassName = raiseEvent DelegateClassName // get the Class name and store it
+		    const superClassName = "NSObject"
+		    dim protocols() as String = raiseEvent DelegateProtocols
+		    
+		    declare function alloc lib CocoaLib selector "alloc" (class_id as Ptr) as Ptr
+		    
+		    // allocate the instance
+		    dim delegate_id as Ptr = Initialize(alloc(RegisterClass(ClassName, superClassName, protocols)))
+		    super.Constructor(delegate_id, NSObject.hasOwnership) // construct the super object (NSObject)
+		    
+		    // store the instance in a static map
+		    CocoaDelegateMap.Value(delegate_id) = new WeakRef(self)
+		  #endif
 		End Sub
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
 		Sub Destructor()
 		  
-		  // if self is still present in the static map, remove it
-		  
-		  if CocoaDelegateMap.HasKey(self.id) then
-		    CocoaDelegateMap.Remove(self.id)
-		  end if
-		  
+		  #if TargetMacOS
+		    // if self is still present in the static map, remove it
+		    
+		    if CocoaDelegateMap.HasKey(self.id) then
+		      CocoaDelegateMap.Remove(self.id)
+		    end if
+		  #endif
 		End Sub
 	#tag EndMethod
 

--- a/macoslib/Cocoa/NSArray.rbbas
+++ b/macoslib/Cocoa/NSArray.rbbas
@@ -885,20 +885,22 @@ Inherits NSObject
 			Get
 			  //# Returns the number of objects currently in the array.
 			  
-			  #if RBVersion >= 2012.02
-			    #if Target32Bit
+			  #if TargetMacOS
+			    #if RBVersion >= 2012.02
+			      #if Target32Bit
+			        declare function m_count lib CocoaLib selector "count" ( obj as Ptr ) as UInt32
+			      #else
+			        declare function m_count lib CocoaLib selector "count" ( obj as Ptr ) as UInt64
+			      #endif
+			      
+			    #else //Previous versions are 32 bits only
 			      declare function m_count lib CocoaLib selector "count" ( obj as Ptr ) as UInt32
-			    #else
-			      declare function m_count lib CocoaLib selector "count" ( obj as Ptr ) as UInt64
 			    #endif
 			    
-			  #else //Previous versions are 32 bits only
-			    declare function m_count lib CocoaLib selector "count" ( obj as Ptr ) as UInt32
+			    dim cnt as integer = m_count( me.id )
+			    
+			    return  cnt
 			  #endif
-			  
-			  dim cnt as integer = m_count( me.id )
-			  
-			  return  cnt
 			End Get
 		#tag EndGetter
 		Count As Integer


### PR DESCRIPTION
* Changed Cocoa.NSClassFromString from External Method to Shared Method. See https://github.com/macoslib/macoslib/issues/178 for the discussion.
* Fixed Cocoa.CocoaDelegate and Cocoa.NSArray using Declare without 'ifdef' block. This leaks dependency to `libobjc.A.dylib`.