### PR TITLE
Fixes for DataWithPDFInsideRect(), DataWithEPSInsideRect() and Cocoa.NSValue.PtrValue

### DIFF
--- a/About.rbbas
+++ b/About.rbbas
@@ -64,6 +64,10 @@ Protected Module About
 		
 		When you make changes, add new notes above existing ones, and remember to increment the Version constant.
 		
+		184: 2015-05-12 by TT (Thanks to jda@his.com for pointing out both of these bugs)
+		- Fixes all DataWithPDFInsideRect() and DataWithEPSInsideRect() functions - they did not return a value before.
+		- Fixes Cocoa.NSValue.PtrValue. Didn't work at all before.
+		
 		183: 2015-02-26 by KM
 		- Changed Cocoa.NSClassFromString from External Method to Shared Method to improve cross-platform compatibility.
 		- Fixed Cocoa.CocoaDelegate and Cocoa.NSArray using Declare without 'ifdef' block.
@@ -572,7 +576,7 @@ Protected Module About
 	#tag EndNote
 
 
-	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"183", Scope = Protected
+	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"184", Scope = Protected
 	#tag EndConstant
 
 

--- a/macoslib/Cocoa/CanvasForNSView.rbbas
+++ b/macoslib/Cocoa/CanvasForNSView.rbbas
@@ -353,35 +353,35 @@ Implements objHasVariantValue
 
 	#tag Method, Flags = &h0
 		Function DataWithEPSInsideRect(aRect as Cocoa.NSRect) As NSData
-		  #if TargetMacOS then
-		    declare sub setDataWithEPSInsideRect lib CocoaLib selector "dataWithEPSInsideRect:" (obj_id as Ptr, aRect as Cocoa.NSRect)
+		  
+		  #if TargetCocoa
+		    declare function dataWithEPSInsideRect lib CocoaLib selector "dataWithEPSInsideRect:" (obj_id as Ptr, aRect as Cocoa.NSRect) as Ptr
 		    
-		    setDataWithEPSInsideRect self, aRect
+		    dim dataRef as Ptr = dataWithEPSInsideRect(self, aRect)
+		    if dataRef <> nil then
+		      return new NSData(dataRef)
+		    end if
+		    
 		  #else
-		    #pragma Unused aRect
+		    #pragma unused aRect
 		  #endif
-		  
-		  
-		  
-		  
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
 		Function DataWithPDFInsideRect(aRect as Cocoa.NSRect) As NSData
+		  
 		  #if TargetMacOS then
-		    declare sub setDataWithPDFInsideRect lib CocoaLib selector "dataWithPDFInsideRect:" (obj_id as Ptr, aRect as Cocoa.NSRect)
+		    declare function dataWithPDFInsideRect lib CocoaLib selector "dataWithPDFInsideRect:" (obj_id as Ptr, aRect as Cocoa.NSRect) as Ptr
 		    
-		    setDataWithPDFInsideRect self, aRect
+		    dim dataRef as Ptr = dataWithPDFInsideRect(self, aRect)
+		    if dataRef <> nil then
+		      return new NSData(dataRef)
+		    end if
+		    
 		  #else
 		    #pragma Unused aRect
 		  #endif
-		  
-		  
-		  
-		  
-		  
 		End Function
 	#tag EndMethod
 

--- a/macoslib/Cocoa/NSValue.rbbas
+++ b/macoslib/Cocoa/NSValue.rbbas
@@ -181,7 +181,7 @@ Inherits NSObject
 	#tag Method, Flags = &h0
 		Function PtrValue() As Ptr
 		  #if targetMacOS
-		    declare function pointerValue lib CocoaLib selector "pointerValue" (obj_id as Ptr) as Ptr
+		    declare function pointerValue lib CocoaLib selector “pointValue" (obj_id as Ptr) as Ptr
 		    
 		    return pointerValue(self)
 		  #endif

--- a/macoslib/Cocoa/NSView.rbbas
+++ b/macoslib/Cocoa/NSView.rbbas
@@ -299,35 +299,35 @@ Inherits NSResponder
 
 	#tag Method, Flags = &h0
 		Function DataWithEPSInsideRect(aRect as Cocoa.NSRect) As NSData
-		  #if TargetMacOS then
-		    declare sub setDataWithEPSInsideRect lib CocoaLib selector "dataWithEPSInsideRect:" (obj_id as Ptr, aRect as Cocoa.NSRect)
+		  
+		  #if TargetCocoa
+		    declare function dataWithEPSInsideRect lib CocoaLib selector "dataWithEPSInsideRect:" (obj_id as Ptr, aRect as Cocoa.NSRect) as Ptr
 		    
-		    setDataWithEPSInsideRect self, aRect
+		    dim dataRef as Ptr = dataWithEPSInsideRect(self, aRect)
+		    if dataRef <> nil then
+		      return new NSData(dataRef)
+		    end if
+		    
 		  #else
-		    #pragma Unused aRect
+		    #pragma unused aRect
 		  #endif
-		  
-		  
-		  
-		  
-		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
 		Function DataWithPDFInsideRect(aRect as Cocoa.NSRect) As NSData
+		  
 		  #if TargetMacOS then
-		    declare sub setDataWithPDFInsideRect lib CocoaLib selector "dataWithPDFInsideRect:" (obj_id as Ptr, aRect as Cocoa.NSRect)
+		    declare function dataWithPDFInsideRect lib CocoaLib selector "dataWithPDFInsideRect:" (obj_id as Ptr, aRect as Cocoa.NSRect) as Ptr
 		    
-		    setDataWithPDFInsideRect self, aRect
+		    dim dataRef as Ptr = dataWithPDFInsideRect(self, aRect)
+		    if dataRef <> nil then
+		      return new NSData(dataRef)
+		    end if
+		    
 		  #else
 		    #pragma Unused aRect
 		  #endif
-		  
-		  
-		  
-		  
-		  
 		End Function
 	#tag EndMethod
 
@@ -2219,6 +2219,11 @@ Inherits NSResponder
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="WantsDefaultClipping"
+			Group="Behavior"
+			Type="Boolean"
+		#tag EndViewProperty
+		#tag ViewProperty
+			Name="WantsLayer"
 			Group="Behavior"
 			Type="Boolean"
 		#tag EndViewProperty

--- a/macoslib/Cocoa/NSWindow.rbbas
+++ b/macoslib/Cocoa/NSWindow.rbbas
@@ -484,7 +484,6 @@ Inherits NSResponder
 		  #else
 		    #pragma unused aRect
 		  #endif
-		  
 		End Function
 	#tag EndMethod
 
@@ -502,7 +501,6 @@ Inherits NSResponder
 		  #else
 		    #pragma unused aRect
 		  #endif
-		  
 		End Function
 	#tag EndMethod
 


### PR DESCRIPTION
- Fixes all DataWithPDFInsideRect() and DataWithEPSInsideRect() functions - they did not return a value before.

- Fixes Cocoa.NSValue.PtrValue. Didn't work at all before.
Bugs and fixes reported by jda@his.com. I (TT) did not test these changes.