### PR TITLE
IoKit: Added IdleTime method

### DIFF
--- a/About.rbbas
+++ b/About.rbbas
@@ -32,6 +32,7 @@ Protected Module About
 		Vidal van Bergen (VVB)
 		Jeff Fowler (JF)
 		Kenichi Maehashi (KM)
+		Jeremy Cowgar (JC)
 	#tag EndNote
 
 	#tag Note, Name = Documentation
@@ -63,6 +64,10 @@ Protected Module About
 		for previous release notes. Contributors are identified by initials. See the "Contributors" note for full names.
 		
 		When you make changes, add new notes above existing ones, and remember to increment the Version constant.
+		
+		186: 2015-06-21 by JC
+		- Added IoKit.IdleTime which returns the user idle time in nano seconds
+		- Added IoKit.IdleTime example, Examples/IOKitIdleTimeExampleWindow
 		
 		185: 2015-05-17 by CY
 		- Remove a smart quote that slipped into v. 184.
@@ -581,7 +586,7 @@ Protected Module About
 	#tag EndNote
 
 
-	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"185", Scope = Protected
+	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"186", Scope = Protected
 	#tag EndConstant
 
 

--- a/Application/App.rbbas
+++ b/Application/App.rbbas
@@ -452,6 +452,13 @@ Inherits Application
 	#tag EndMenuHandler
 
 	#tag MenuHandler
+		Function IOKitIdleTime() As Boolean Handles IOKitIdleTime.Action
+			IOKitIdleTimeExampleWindow.Show
+			return True
+		End Function
+	#tag EndMenuHandler
+
+	#tag MenuHandler
 		Function IOKitPrimaryMACAddress() As Boolean Handles IOKitPrimaryMACAddress.Action
 			IOKitPrimaryMACAddressExample.Show
 			return true

--- a/Application/MainMenubar.rbmnu
+++ b/Application/MainMenubar.rbmnu
@@ -1310,6 +1310,13 @@ Begin Menu MainMenubar
             Index = -2147483648
             AutoEnable = True
          End
+         Begin MenuItem IOKitIdleTime
+            SpecialMenu = 0
+            Text = "Idle Time"
+            Index = -2147483648
+            AutoEnable = True
+            Visible = True
+         End
          Begin MenuItem IOKitExternalPowerAdapter
             SpecialMenu = 0
             Text = "External Power Adapter"

--- a/Examples/IOKitIdleTimeExampleWindow.xojo_window
+++ b/Examples/IOKitIdleTimeExampleWindow.xojo_window
@@ -1,0 +1,314 @@
+#tag Window
+Begin Window IOKitIdleTimeExampleWindow
+   BackColor       =   &cFFFFFF00
+   Backdrop        =   0
+   CloseButton     =   True
+   Compatibility   =   ""
+   Composite       =   False
+   Frame           =   0
+   FullScreen      =   False
+   FullScreenButton=   False
+   HasBackColor    =   False
+   Height          =   112
+   ImplicitInstance=   True
+   LiveResize      =   True
+   MacProcID       =   0
+   MaxHeight       =   32000
+   MaximizeButton  =   False
+   MaxWidth        =   32000
+   MenuBar         =   0
+   MenuBarVisible  =   True
+   MinHeight       =   64
+   MinimizeButton  =   True
+   MinWidth        =   64
+   Placement       =   0
+   Resizeable      =   True
+   Title           =   "Idle Time"
+   Visible         =   True
+   Width           =   298
+   Begin Label IdleTimeLabel
+      AutoDeactivate  =   True
+      Bold            =   True
+      DataField       =   ""
+      DataSource      =   ""
+      Enabled         =   True
+      Height          =   72
+      HelpTag         =   ""
+      Index           =   -2147483648
+      InitialParent   =   ""
+      Italic          =   False
+      Left            =   20
+      LockBottom      =   True
+      LockedInPosition=   False
+      LockLeft        =   True
+      LockRight       =   True
+      LockTop         =   True
+      Multiline       =   False
+      Scope           =   2
+      Selectable      =   False
+      TabIndex        =   1
+      TabPanelIndex   =   0
+      Text            =   "0"
+      TextAlign       =   1
+      TextColor       =   &c00000000
+      TextFont        =   "System"
+      TextSize        =   48.0
+      TextUnit        =   0
+      Top             =   20
+      Transparent     =   False
+      Underline       =   False
+      Visible         =   True
+      Width           =   258
+   End
+   Begin Timer UpdateIdleTimer
+      Height          =   32
+      Index           =   -2147483648
+      Left            =   0
+      LockedInPosition=   False
+      Mode            =   2
+      Period          =   1000
+      Scope           =   2
+      TabPanelIndex   =   0
+      Top             =   0
+      Width           =   32
+   End
+End
+#tag EndWindow
+
+#tag WindowCode
+#tag EndWindowCode
+
+#tag Events UpdateIdleTimer
+	#tag Event
+		Sub Action()
+		  IdleTimeLabel.Text = Format(IdleTime / 1000000000, "#,##0")
+		End Sub
+	#tag EndEvent
+#tag EndEvents
+#tag ViewBehavior
+	#tag ViewProperty
+		Name="BackColor"
+		Visible=true
+		Group="Appearance"
+		InitialValue="&hFFFFFF"
+		Type="Color"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="Backdrop"
+		Visible=true
+		Group="Appearance"
+		Type="Picture"
+		EditorType="Picture"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="CloseButton"
+		Visible=true
+		Group="Appearance"
+		InitialValue="True"
+		Type="Boolean"
+		EditorType="Boolean"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="Composite"
+		Group="Appearance"
+		InitialValue="False"
+		Type="Boolean"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="Frame"
+		Visible=true
+		Group="Appearance"
+		InitialValue="0"
+		Type="Integer"
+		EditorType="Enum"
+		#tag EnumValues
+			"0 - Document"
+			"1 - Movable Modal"
+			"2 - Modal Dialog"
+			"3 - Floating Window"
+			"4 - Plain Box"
+			"5 - Shadowed Box"
+			"6 - Rounded Window"
+			"7 - Global Floating Window"
+			"8 - Sheet Window"
+			"9 - Metal Window"
+			"10 - Drawer Window"
+			"11 - Modeless Dialog"
+		#tag EndEnumValues
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="FullScreen"
+		Group="Appearance"
+		InitialValue="False"
+		Type="Boolean"
+		EditorType="Boolean"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="FullScreenButton"
+		Visible=true
+		Group="Appearance"
+		InitialValue="False"
+		Type="Boolean"
+		EditorType="Boolean"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="HasBackColor"
+		Visible=true
+		Group="Appearance"
+		InitialValue="False"
+		Type="Boolean"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="Height"
+		Visible=true
+		Group="Position"
+		InitialValue="400"
+		Type="Integer"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="ImplicitInstance"
+		Visible=true
+		Group="Appearance"
+		InitialValue="True"
+		Type="Boolean"
+		EditorType="Boolean"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="Interfaces"
+		Visible=true
+		Group="ID"
+		Type="String"
+		EditorType="String"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="LiveResize"
+		Visible=true
+		Group="Appearance"
+		InitialValue="True"
+		Type="Boolean"
+		EditorType="Boolean"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="MacProcID"
+		Group="Appearance"
+		InitialValue="0"
+		Type="Integer"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="MaxHeight"
+		Visible=true
+		Group="Position"
+		InitialValue="32000"
+		Type="Integer"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="MaximizeButton"
+		Visible=true
+		Group="Appearance"
+		InitialValue="True"
+		Type="Boolean"
+		EditorType="Boolean"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="MaxWidth"
+		Visible=true
+		Group="Position"
+		InitialValue="32000"
+		Type="Integer"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="MenuBar"
+		Visible=true
+		Group="Appearance"
+		Type="MenuBar"
+		EditorType="MenuBar"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="MenuBarVisible"
+		Group="Appearance"
+		InitialValue="True"
+		Type="Boolean"
+		EditorType="Boolean"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="MinHeight"
+		Visible=true
+		Group="Position"
+		InitialValue="64"
+		Type="Integer"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="MinimizeButton"
+		Visible=true
+		Group="Appearance"
+		InitialValue="True"
+		Type="Boolean"
+		EditorType="Boolean"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="MinWidth"
+		Visible=true
+		Group="Position"
+		InitialValue="64"
+		Type="Integer"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="Name"
+		Visible=true
+		Group="ID"
+		Type="String"
+		EditorType="String"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="Placement"
+		Visible=true
+		Group="Position"
+		InitialValue="0"
+		Type="Integer"
+		EditorType="Enum"
+		#tag EnumValues
+			"0 - Default"
+			"1 - Parent Window"
+			"2 - Main Screen"
+			"3 - Parent Window Screen"
+			"4 - Stagger"
+		#tag EndEnumValues
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="Resizeable"
+		Visible=true
+		Group="Appearance"
+		InitialValue="True"
+		Type="Boolean"
+		EditorType="Boolean"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="Super"
+		Visible=true
+		Group="ID"
+		Type="String"
+		EditorType="String"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="Title"
+		Visible=true
+		Group="Appearance"
+		InitialValue="Untitled"
+		Type="String"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="Visible"
+		Visible=true
+		Group="Appearance"
+		InitialValue="True"
+		Type="Boolean"
+		EditorType="Boolean"
+	#tag EndViewProperty
+	#tag ViewProperty
+		Name="Width"
+		Visible=true
+		Group="Position"
+		InitialValue="600"
+		Type="Integer"
+	#tag EndViewProperty
+#tag EndViewBehavior

--- a/macoslib.rbvcp
+++ b/macoslib.rbvcp
@@ -180,6 +180,7 @@ Folder=ImageKit and ImageCapture Examples;Examples/ImageKit and ImageCapture Exa
 Window=ImageTransformExample;Examples/ImageTransformExample.rbfrm;&h1AE19A10;&h4BD59C08;false
 Window=IOKitExternalPowerWindow;Examples/IOKitExternalPowerWindow.rbfrm;&h60DD7C48;&h4BD59C08;false
 Window=IOKitPrimaryMACAddressExample;Examples/IOKitPrimaryMACAddressExample.rbfrm;&h20AD9A2F;&h4BD59C08;false
+Window=IOKitIdleTimeExampleWindow;Examples/IOKitIdleTimeExampleWindow.xojo_window;&h66AE3FFF;&h4BD59C08;false
 Window=LabelExtensionExampleWindow;Examples/LabelExtensionExampleWindow.rbfrm;&h2CBC474;&h4BD59C08;false
 Window=LanguagesWindow;Examples/LanguagesWindow.rbfrm;&h3152B679;&h4BD59C08;false
 Window=MacDatePickerExampleWindow;Examples/MacDatePickerExampleWindow.rbfrm;&h3FFC42FA;&h4BD59C08;false

--- a/macoslib/IOKit/IOKit.rbbas
+++ b/macoslib/IOKit/IOKit.rbbas
@@ -90,10 +90,10 @@ Protected Module IOKit
 		  dim idleNanoSecs as Int64 = -1
 		  
 		  #if TargetMacOS
-		    soft declare function IOServiceMatching lib IOKit (name as CString) as Ptr
-		    soft declare function IOServiceGetMatchingServices lib IOKit (masterPort as UInt32, matching as Ptr, ByRef existing as UInt32) as Integer
-		    soft declare function IOIteratorNext lib IOKit (iterator as UInt32) as UInt32
-		    soft declare function IORegistryEntryCreateCFProperties lib IOKit (entry as UInt32, ByRef properties as Ptr, allocator as Ptr, options as UInt32) as Integer
+		    declare function IOServiceMatching lib IOKit (name as CString) as Ptr
+		    declare function IOServiceGetMatchingServices lib IOKit (masterPort as UInt32, matching as Ptr, ByRef existing as UInt32) as Integer
+		    declare function IOIteratorNext lib IOKit (iterator as UInt32) as UInt32
+		    declare function IORegistryEntryCreateCFProperties lib IOKit (entry as UInt32, ByRef properties as Ptr, allocator as Ptr, options as UInt32) as Integer
 		    
 		    const kHIDIdleTime = "HIDIdleTime"
 		    const kKernSuccess = 0


### PR DESCRIPTION
Returns the number of nanoseconds the user has been idle. The method and an example window have been added. This is the first time I have contributed to macoslib and the first time I have done any OS X specific external method work, so before merging it would be nice to have an experienced macoslib developer double check the work in IoKit.IdleTime.

Thanks!