### PR TITLE
Add support for dates in preferences

### DIFF
--- a/Additional Modules/TT's SmartPreferences/TTsSmartPreferences.rbbas
+++ b/Additional Modules/TT's SmartPreferences/TTsSmartPreferences.rbbas
@@ -223,6 +223,8 @@ Protected Class TTsSmartPreferences
 		    newv = CFNumber(v.DoubleValue)
 		  case v.TypeString, v.TypeCFStringRef
 		    newv = CFString(v.StringValue)
+		  case v.TypeDate
+		    newv = CFDate(v.DateValue)
 		  case v.TypeObject
 		    if v.ObjectValue isA Dictionary then
 		      dim d as Dictionary = v


### PR DESCRIPTION
There was already support in macoslib for CFDate, so I added a case to handle converting a Xojo Date to a CFDate in preferences.
