### PR TITLE
Small changes to allow TT's SmartPreferences to compile for 64-bit

### DIFF
--- a/macoslib/Cocoa/NSArray.rbbas
+++ b/macoslib/Cocoa/NSArray.rbbas
@@ -651,7 +651,11 @@ Inherits NSObject
 		  dim m as MemoryBlock = self.ValuesArray(arrayRange)
 		  dim n as UInt32 = arrayRange.length-1
 		  for i as integer = 0 to n
-		    retArray.append new NSString(Ptr(m.UInt32Value(i*SizeOfPointer)))
+		    #if Target64Bit then
+		      retArray.append new NSString(Ptr(m.UInt64Value(i*8)))
+		    #else
+		      retArray.append new NSString(Ptr(m.UInt32Value(i*4)))
+		    #endif
 		  next
 		  
 		  return retArray
@@ -758,7 +762,11 @@ Inherits NSObject
 		  
 		  dim n as UInt32 = aRange.length-1
 		  for i as integer = 0 to n
-		    rb_array.append new NSObject(Ptr(m.UInt32Value(i*SizeOfPointer)))
+		    #if Target64Bit then
+		      rb_array.append new NSObject(Ptr(m.UInt64Value(i*8)))
+		    #else
+		      rb_array.append new NSObject(Ptr(m.UInt32Value(i*4)))
+		    #endif
 		  next
 		  
 		  return rb_array

--- a/macoslib/CoreFoundation/CoreFoundation.rbbas
+++ b/macoslib/CoreFoundation/CoreFoundation.rbbas
@@ -77,7 +77,7 @@ Module CoreFoundation
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Function CFNumber(int_32 as Integer) As CFNumber
+		Function CFNumber(int_32 as Int32) As CFNumber
 		  return new CFNumber(int_32)
 		End Function
 	#tag EndMethod

--- a/macoslib/Misc/macoslib_32_64bits_savviness.rbbas
+++ b/macoslib/Misc/macoslib_32_64bits_savviness.rbbas
@@ -59,7 +59,9 @@ Protected Module macoslib_32_64bits_savviness
 		  //@discussion/
 		  
 		  if SizeOfPointer=4 then //32 bits
-		    return  Ptr( mb.UInt32Value( offset ))
+		    #if Target32Bit
+		      return  Ptr( mb.UInt32Value( offset ))
+		    #endif
 		    
 		  else //64 bits
 		    #if RBVersion>= 2013
@@ -87,7 +89,9 @@ Protected Module macoslib_32_64bits_savviness
 		  //Note: ShiftLeft is quicker than a multiplication
 		  
 		  if SizeOfPointer=4 then //32 bits
-		    return  Ptr( mb.UInt32Value( Bitwise.ShiftLeft( ArrayIndex, 2 )))
+		    #if Target32Bit
+		      return  Ptr( mb.UInt32Value( Bitwise.ShiftLeft( ArrayIndex, 2 )))
+		    #endif
 		    
 		  else //64 bits
 		    #if RBVersion>= 2013


### PR DESCRIPTION
My code relies on TT's SmartPreferences, and these changes allow the compilation for Linux 64-bit. With these changes the preferences seem to be read and written properly both on OS X (32-bit) and linux (64-bit). Not sure if I haven't broken something else
