### PR TITLE
NSUserNotification without sound possible

### DIFF
--- a/Examples/NSUserNotificationExample.rbfrm
+++ b/Examples/NSUserNotificationExample.rbfrm
@@ -754,6 +754,7 @@ End
 		  if edtOther.Text <> "" then n.otherButtonTitle = edtOther.Text
 		  
 		  if edtSoundName.Text <> "" then n.SoundName = edtSoundName.Text
+		  // To Play no Sound for a notification set n.SoundName = NIL
 		  
 		  return n
 		End Function

--- a/macoslib/Cocoa/NSNotificationCenter.rbbas
+++ b/macoslib/Cocoa/NSNotificationCenter.rbbas
@@ -40,9 +40,8 @@ Inherits NSObject
 		    dim notificationRef as Ptr
 		    if notification <> nil then
 		      notificationRef = notification
+		      postNotification self, notificationRef
 		    end if
-		    
-		    postNotification self, notificationRef
 		    
 		  #else
 		    #pragma unused notification

--- a/macoslib/Cocoa/NSUserNotification.rbbas
+++ b/macoslib/Cocoa/NSUserNotification.rbbas
@@ -312,7 +312,9 @@ Inherits NSObject
 			  #if TargetMacOS then
 			    declare function soundName lib CocoaLib selector "soundName" (obj_id as Ptr) as CFStringRef
 			    
-			    return soundName(self)
+			    dim buffer as string
+			    buffer = SoundName(self)
+			    return buffer
 			  #endif
 			End Get
 		#tag EndGetter
@@ -322,13 +324,20 @@ Inherits NSObject
 			  #if TargetMacOS then
 			    declare sub setSoundName lib CocoaLib selector "setSoundName:" (obj_id as Ptr, value as CFStringRef)
 			    
-			    setSoundName self, value
+			    if value = NIL then
+			      setSoundName self, NIL
+			    else
+			      dim buffer as string
+			      buffer = cstr(value)
+			      setSoundName self, buffer
+			    end if
+			    
 			  #else
 			    #pragma Unused value
 			  #endif
 			End Set
 		#tag EndSetter
-		SoundName As String
+		SoundName As Variant
 	#tag EndComputedProperty
 
 	#tag ComputedProperty, Flags = &h0
@@ -423,6 +432,11 @@ Inherits NSObject
 			Group="Behavior"
 			Type="String"
 			EditorType="MultiLineEditor"
+		#tag EndViewProperty
+		#tag ViewProperty
+			Name="ActivationType"
+			Group="Behavior"
+			Type="NSUserNotificationActivationType"
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Description"


### PR DESCRIPTION
I changed the declaration for NSUserNotification in that way that one
can set the value NIL for sound name. This suppresses the sound for a
notification, where an empty string plays the default sound.
