### PR TITLE
		- Fixed clashing method name in StringExtension 'Contains' to 'Cont…

### DIFF
--- a/About.xojo_code
+++ b/About.xojo_code
@@ -73,6 +73,12 @@ Protected Module About
 		
 		When you make changes, add new notes above existing ones, and remember to increment the Version constant.
 		
+		222: 2022-08-06 by VVB
+		- Fixed clashing method name in StringExtension 'Contains' to 'ContainsString', and 'ContainsB' to match into 'ContainsStringB'.
+		- Modified existing uses in the example projects to use 'ContainsString' to remain backwards compatible.
+		- Altered the layout of the NSToolbar example window.
+		- Set CoreFoundation.CFRange to integer for 64bit compatibility.
+		
 		221: 2022-01-03 by VVB
 		- Renamed PDFDocument class in PDFKit to mlPDFDocument because the name clashed with a recently added class in Xojo 2021R3.1.
 		
@@ -722,7 +728,7 @@ Protected Module About
 	#tag EndNote
 
 
-	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"221", Scope = Protected
+	#tag Constant, Name = Version, Type = Double, Dynamic = False, Default = \"222", Scope = Protected
 	#tag EndConstant
 
 

--- a/Additional Modules/Class Extensions/AlertExtensions.xojo_code
+++ b/Additional Modules/Class Extensions/AlertExtensions.xojo_code
@@ -6,7 +6,7 @@ Protected Module AlertExtensions
 		  
 		  dim nsa as New NSAlert( Message )
 		  
-		  if Message.Contains( splitValue ) then
+		  if Message.ContainsString( splitValue ) then
 		    nsa.MessageText = Message.NthField( splitValue, 1 )
 		    nsa.InformativeText = Message.NthField( splitValue, 2 )
 		  end if

--- a/Additional Modules/Class Extensions/StringExtension.xojo_code
+++ b/Additional Modules/Class Extensions/StringExtension.xojo_code
@@ -11,7 +11,7 @@ Protected Module StringExtension
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Function Contains(extends s as string, substring as String) As Boolean
+		Function ContainsString(extends s as string, substring as String) As Boolean
 		  //# Return true if 'substring' is contained in 's' (comparison is case-insensitive)
 		  
 		  return  ( s.Instr( substring ) > 0 )
@@ -19,7 +19,7 @@ Protected Module StringExtension
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Function ContainsB(extends s as string, substring as String) As Boolean
+		Function ContainsStringB(extends s as string, substring as String) As Boolean
 		  //# Return true if 's' contains the 'substring'.
 		  
 		  //@ By 'contains' we mean binary containment, as with InStrB.

--- a/Examples/NSToolbarWindow.xojo_window
+++ b/Examples/NSToolbarWindow.xojo_window
@@ -17,14 +17,14 @@ Begin Window NSToolbarWindow
    MaxWidth        =   32000
    MenuBar         =   0
    MenuBarVisible  =   True
-   MinHeight       =   64
+   MinHeight       =   345
    MinimizeButton  =   True
-   MinWidth        =   64
+   MinWidth        =   845
    Placement       =   0
    Resizeable      =   True
    Title           =   "NSToolbar Example"
    Visible         =   True
-   Width           =   846
+   Width           =   1124
    Begin TextArea TextArea1
       AcceptTabs      =   False
       Alignment       =   0
@@ -42,7 +42,7 @@ Begin Window NSToolbarWindow
       HideSelection   =   True
       Index           =   -2147483648
       Italic          =   False
-      Left            =   474
+      Left            =   752
       LimitText       =   0
       LineHeight      =   0.0
       LineSpacing     =   1.0
@@ -105,7 +105,7 @@ Begin Window NSToolbarWindow
       Underline       =   False
       Value           =   False
       Visible         =   True
-      Width           =   165
+      Width           =   443
    End
    Begin Label lblArray
       AutoDeactivate  =   True
@@ -155,7 +155,7 @@ Begin Window NSToolbarWindow
       Index           =   -2147483648
       InitialParent   =   ""
       Italic          =   False
-      Left            =   382
+      Left            =   660
       LockBottom      =   False
       LockedInPosition=   False
       LockLeft        =   False
@@ -204,7 +204,7 @@ Begin Window NSToolbarWindow
       Transparent     =   False
       Underline       =   False
       Visible         =   True
-      Width           =   196
+      Width           =   474
    End
    Begin CheckBox CheckBox2
       AutoDeactivate  =   True
@@ -237,7 +237,7 @@ Begin Window NSToolbarWindow
       Underline       =   False
       Value           =   False
       Visible         =   True
-      Width           =   193
+      Width           =   471
    End
    Begin CheckBox chkFullSizeContentView
       AutoDeactivate  =   True
@@ -270,7 +270,7 @@ Begin Window NSToolbarWindow
       Underline       =   False
       Value           =   False
       Visible         =   True
-      Width           =   190
+      Width           =   468
    End
    Begin CheckBox CheckBox3
       AutoDeactivate  =   True
@@ -303,7 +303,7 @@ Begin Window NSToolbarWindow
       Underline       =   False
       Value           =   True
       Visible         =   True
-      Width           =   193
+      Width           =   471
    End
    Begin Canvas Canvas1
       AcceptFocus     =   False
@@ -448,7 +448,6 @@ Begin Window NSToolbarWindow
          SelectionType   =   0
          TabIndex        =   2
          TabPanelIndex   =   0
-         TabStop         =   True
          Top             =   -85
          Transparent     =   False
          Visible         =   True
@@ -485,7 +484,7 @@ Begin Window NSToolbarWindow
       Transparent     =   False
       Underline       =   False
       Visible         =   True
-      Width           =   190
+      Width           =   468
    End
    Begin Label lblArray
       AutoDeactivate  =   True
@@ -552,7 +551,7 @@ Begin Window NSToolbarWindow
       Transparent     =   False
       Underline       =   False
       Visible         =   True
-      Width           =   190
+      Width           =   468
    End
    Begin Label lblArray
       AutoDeactivate  =   True
@@ -600,7 +599,7 @@ Begin Window NSToolbarWindow
       Index           =   2
       InitialParent   =   ""
       Italic          =   False
-      Left            =   382
+      Left            =   660
       LockBottom      =   False
       LockedInPosition=   False
       LockLeft        =   False
@@ -635,7 +634,7 @@ Begin Window NSToolbarWindow
       Index           =   3
       InitialParent   =   ""
       Italic          =   False
-      Left            =   382
+      Left            =   660
       LockBottom      =   False
       LockedInPosition=   False
       LockLeft        =   False
@@ -748,7 +747,7 @@ Begin Window NSToolbarWindow
       Index           =   4
       InitialParent   =   ""
       Italic          =   False
-      Left            =   382
+      Left            =   660
       LockBottom      =   False
       LockedInPosition=   False
       LockLeft        =   False
@@ -783,7 +782,7 @@ Begin Window NSToolbarWindow
       Index           =   1
       InitialParent   =   ""
       Italic          =   False
-      Left            =   382
+      Left            =   660
       LockBottom      =   False
       LockedInPosition=   False
       LockLeft        =   False
@@ -818,7 +817,7 @@ Begin Window NSToolbarWindow
       Index           =   0
       InitialParent   =   ""
       Italic          =   False
-      Left            =   382
+      Left            =   660
       LockBottom      =   False
       LockedInPosition=   False
       LockLeft        =   False
@@ -1157,10 +1156,10 @@ End
 		Sub Open()
 		  me.SegmentStyle = SegmentedControlExtension.NSSegmentStyle.TexturedRounded
 		  
-		  me.ImageForSegment(0) = SystemIcons.IconViewTemplate( 0, 10 )
-		  me.ImageForSegment(1) = SystemIcons.ListViewTemplate( 0, 10 )
-		  me.ImageForSegment(2) = SystemIcons.ColumnViewTemplate( 0, 10 )
-		  me.ImageForSegment(3) = SystemIcons.FlowViewTemplate( 0, 10 )
+		  me.ImageForSegment(0) = SystemIcons.IconViewTemplate( 0, 8 )
+		  me.ImageForSegment(1) = SystemIcons.ListViewTemplate( 0, 8 )
+		  me.ImageForSegment(2) = SystemIcons.ColumnViewTemplate( 0, 8 )
+		  me.ImageForSegment(3) = SystemIcons.FlowViewTemplate( 0, 8 )
 		  
 		  for i as Integer = 0 to 3
 		    me.ImageForSegment(i).Template = true

--- a/Examples/SystemIconsExampleWindow.xojo_window
+++ b/Examples/SystemIconsExampleWindow.xojo_window
@@ -784,7 +784,7 @@ End
 		    w = 0.0
 		    h = 0.0
 		    
-		    if names(0).Contains("TouchBar") and NOT IsSierra then
+		    if names(0).ContainsString("TouchBar") and NOT IsSierra then
 		      // Touchbar icons aren't available before Mac OS 10.12 Sierra.
 		      Continue
 		    end if
@@ -847,12 +847,12 @@ End
 		      end if
 		      
 		      PB1.Image = Pict
-		      PB1.Image.Template = me.Cell( me.ListIndex, 0 ).Contains( "Template" )
+		      PB1.Image.Template = me.Cell( me.ListIndex, 0 ).ContainsString( "Template" )
 		      PB1.Image.Size = Cocoa.NSMakeSize( w, h )
 		      PB1.Invalidate
 		      
 		      SC1.ImageForSegment(0) = pict
-		      SC1.ImageForSegment(0).Template = me.Cell( me.ListIndex, 0 ).Contains( "Template" )
+		      SC1.ImageForSegment(0).Template = me.Cell( me.ListIndex, 0 ).ContainsString( "Template" )
 		      SC1.ImageForSegment(0).Size = Cocoa.NSMakeSize( w, h )
 		      SC1.Invalidate
 		    end if
@@ -1057,7 +1057,7 @@ End
 		  
 		  if LB1.ListIndex > -1 then
 		    dim pict1 as Picture = LB1.CellTag(LB1.ListIndex, 0)
-		    if IsDarkMode and LB1.Cell(LB1.ListIndex, 0).Contains("template") then
+		    if IsDarkMode and LB1.Cell(LB1.ListIndex, 0).ContainsString("template") then
 		      pict1 = pict1.IconTemplateSetColor( &cFFFFFF )
 		    end if
 		    g.DrawPicture pict1, 1 + (g.Width/2) - (Val( TF1.Text )/2), 1 + (g.Height/2) - (Val( TF2.Text )/2),  Val( TF1.Text ), Val( TF2.Text ),   0, 0, pict1.Width, pict1.Height

--- a/macoslib/CoreFoundation.xojo_code
+++ b/macoslib/CoreFoundation.xojo_code
@@ -77,7 +77,7 @@ Module CoreFoundation
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Function CFRangeMake(loc as Int32, len as Int32) As CFRange
+		Function CFRangeMake(loc as Integer, len as Integer) As CFRange
 		  dim r as CFRange
 		  r.location = loc
 		  r.length = len
@@ -631,8 +631,8 @@ Module CoreFoundation
 
 
 	#tag Structure, Name = CFRange, Flags = &h0
-		location as Int32
-		length as Int32
+		location as Integer
+		length as Integer
 	#tag EndStructure
 
 	#tag Structure, Name = CFSocketContext, Flags = &h0


### PR DESCRIPTION
		- Fixed clashing method name in StringExtension 'Contains' to 'ContainsString', and 'ContainsB' to match into 'ContainsStringB'.
		- Modified existing uses in the example projects to use 'ContainsString' to remain backwards compatible.
		- Altered the layout of the NSToolbar example window.
		- Set CoreFoundation.CFRange to integer for 64bit compatibility.